### PR TITLE
add 412 name variants to harmonize-names.csv

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # franchise-fruns News
 
+## 2026-05-26
+
+### 412 name variants added to `harmonize-names.csv`
+
+Bulk addition of harmonization rules generated from unmatched names in
+the franchise-metadata pipeline. Mostly long-form FDD names with
+trailing descriptors, regional qualifiers, or multi-brand listings
+(e.g., "togos restaurant" to "togos", "jan pro northwest" to "jan pro
+cleaning disinfecting"). A smaller share are spelling variants and
+alias corrections.
+
 ## 2026-03-04
 
 ### New name mappings added to `harmonize-names.csv`

--- a/data/harmonize-names.csv
+++ b/data/harmonize-names.csv
@@ -1,5 +1,4 @@
 franchise,name_harmonized
-—ènr tire express,rnr tire express
 01 asian fusion,oi asian fusion
 011 vinegar,oil vinegar
 1 800 flowers conroys,1 800 flowers
@@ -42,6 +41,7 @@ franchise,name_harmonized
 911 driving school swerve driving school,911 driving school
 9round 30 min kickbox fitness,9round kickboxing fitness
 9round fitness,9round kickboxing fitness
+I heart caregiver services,1heart caregiver services
 a 1 concrete leveling,a 1 concrete leveling foundation repair
 a better solution in home care brand,a better solution in home care
 "a buyer’s choice home inspections usa, llc",a buyers choice home inspections
@@ -49,8 +49,11 @@ a handyman connection,handyman connection
 a la mode shoppe,a la mode shoppes
 a modo yoga,modo yoga
 a w brand,a w
+a w co brand,a w
+a w co brand restaurant,a w
 a w express,a w
 a1 eds,al eds autosound
+a1 eds stores,al eds autosound
 aa decorative concrete,all american decorative concrete
 aai republic brazilian juice bar,acai republic
 aamco transmission,aamco
@@ -63,18 +66,23 @@ abbey,abbey carpet floor
 abbey carp,abbey carpet floor
 abbey carpet,abbey carpet floor
 abbey carpet abbey carpet floor showrooms,abbey carpet floor
+abbey carpet co inc abbey carpet floor showrooms,abbey carpet floor
 abbey carpet floor showroom,abbey carpet floor
 abbey carpet floor showrooms,abbey carpet floor
 above grade level in home tutoring,above grade level
 abra,abra auto body glass
 abra automotive systems,abra auto body glass
 abrakaddodle,abrakadoodle
+absamc american british surgical medical center,american british surgical medical center
 absolute results training,absolute results
+ac hotels,ac hotels marriott
 acai express superfood bowls,acai express
+acai republic the brazilian juice bar cafes,acai republic
 accruity valuation,accurity valuation
 ace americas cash express,ace cash express
 ace duraflo systems,ace duraflo
 ace handyman,ace handyman services
+ace handyman matters,ace handyman services
 acfn atm business,acfn
 acti kare,actikare in home care service
 actikare in home care services,actikare in home care service
@@ -83,11 +91,13 @@ action coach,actioncoach
 actioncoach business coach,actioncoach
 actioncoach business coaching,actioncoach
 actioncoach master license,actioncoach
+actioncoach mid atlantic,actioncoach
 actioncoach north america,actioncoach
 actioncoach oneco,actioncoach
 actioncoach practice,actioncoach
 activerx active aging center,activerx
 activerx center,activerx
+activerx strengththerapy center,activerx
 adam eve stores,adam eve
 advance realty,advance realty solutions
 advanced maintenance,advanced maintenance on site vehicle services
@@ -95,6 +105,7 @@ advanta clean,advantaclean
 advanta clean systems,advantaclean
 advantaclean environmental,advantaclean
 advantaclean systems,advantaclean
+advantage performance group,advantage performance
 advantage plus caregivers,advantagepluscaregiverscom
 advantagepluscaregivers,advantagepluscaregiverscom
 adventure kids play care,adventure kids playcare
@@ -106,6 +117,7 @@ afc doctors express,american family care
 afc doctors express urgent care,american family care
 afc franch1s1ng,afc
 afc sushi,afc
+afc urgent care,afc
 afcfc,afc
 afficient academy learning center,afficient academy
 affiliated car rental lc,affordable car rental
@@ -119,13 +131,20 @@ aire master america,aire master
 aire serv heating air conditioning,aire serv
 aireserv,aire serv
 al eds,al eds autosound
+al eds stores,al eds autosound
 alabama hamra kabob grill,al hamra kabob grill
 alair homes master franchises,alair homes
 alair homes rd,alair homes
+alair homes regional developer,alair homes
 alamo drafthouse cinemas,alamo drafthouse cinema
+all american ice cream frozen yogurt shops all american deli ice cream sertinos coffee shops sertinos cafes,all american ice cream frozen yogurt
+all american ice cream frozen yogurt shops sertimos coffee shops all american specialty restaurants,all american ice cream frozen yogurt
+all american ice cream frozen yogurt shops sertinos coffee shops sertinos cafes,all american ice cream frozen yogurt
 all american sertinos,sertinos
 all dry services,all dry
 all labs tests fast,all lab tests fast
+all medsearch all med practitioners search all med financial sales search,all medsearch
+all tune lube atl motor mate all tune transmissions,all tune lube
 all tune lube centers atl motor mate all tune transmissions,atl motor mate
 allegra (rsvp),allegra
 allegra american speedy printing insty prints,allegra
@@ -142,6 +161,7 @@ alloy wheel repair,alloy wheel repair specialists
 aloft,aloft hotels
 aloha imind math,aloha
 aloha mind math,aloha
+aloha usa d b a texas aloha mind math,aloha
 alpha graph,alphagraphics
 alpha graphics,alphagraphics
 alphagraph,alphagraphics
@@ -153,6 +173,8 @@ alta cal tech ser aces,alta cal tech services
 alta calendar technology services,alta cal tech services
 alta gal tech services,alta cal tech services
 alta mere,smartview window solutions
+alta mere alta mere milex co branding alta mere smartview co branding milex complete auto care smartview,smartview window solutions
+alta mere smartview,smartview window solutions
 alta mere toys for your car,smartview window solutions
 alternative board,tab the alternative board
 always best care,always best care senior services
@@ -180,13 +202,16 @@ american prosperity group,apg american prosperity
 american wholesale thermographers center,american wholesale thermographers
 americanexpress,american express travel
 americare amli care,americare
+americare area representative,americare
 americas best inn,americas best value inn
 americas swimming pool,asp americas swimming pool
 amerihost,amerihost inn suites
 ameriprise,ameriprise financial
+ameriprise financial services inc independent advisor,ameriprise financial
 ameriprise financial services inc independent advisor business,ameriprise financial
 ameriprise financial services independent advisor business,ameriprise financial
 ameriprise financial services llc independent advisor,ameriprise financial
+ameriprise financial services llc independent advisor business,ameriprise financial
 amerispec,amerispec inspection services
 amerispec home inspection serv,amerispec inspection services
 amerispec home inspection services,amerispec inspection services
@@ -194,6 +219,7 @@ ameritel,NA
 amonno,amorino
 amormo,amorino
 ampm mini market,ampm
+ampm mini markets,ampm
 anago bay area,anago cleaning
 anago cleaning systems,anago cleaning
 anago northern california,anago cleaning
@@ -210,35 +236,43 @@ anvi farms,avni farms
 any test,any lab test now
 anylab,any lab test now
 apa,american poolplayers association
+apartments marriott,apartments marriott bonvoy
 apell striping,appell striping
 apex,apex leadership
+apex franchise,apex leadership
 apex fun run,apex leadership
+apex network,apex leadership
 apex network physical therapy,apexnetwork physical therapy
+apg american prosperity group,apg american prosperity
 apla greek grill,apola greek grill
-apóla greek grill,apola greek grill
+apostle radon indoor air solutions,apostle radon
 apple spice caf bakery,apple spice
 apple spice cafe and bakery,apple spice
+apple spice cafe bakery,apple spice
 applebee’s neighborhood grill & bar,applebees neighborhood grill bar
 apricot lane 28th,apricot lane
 apricot lane boutique,apricot lane
+apóla greek grill,apola greek grill
 aqua chill,aqua chill drinking water
 aqua tots swim school,aqua tots swim schools
 aquapro residential enhancement servicessm,aquapro
 ar homes,alair homes
 ar homes (arthur rutenberg homes),ar homes arthur rutenberg
-arby’s,arbys
 arbys restaurant group,arbys
+arby’s,arbys
 arc point labs,arcpoint labs
 archivelt,archiveit
 arco,ampm
 arcpoint,arcpoint labs
 arcpoint group,arcpoint labs
 art having fun,color me mine
+art recovery technologies,art
 artichoke basilles pizza artichoke pizza,artichoke pizza
 ascend,ascend hotel collection
 ascend collection,ascend hotel collection
 ascend hotel collection ascend resort collection,ascend hotel collection
 ascend hotel collection or ascend resort collection,ascend hotel collection
+asi sign,asi
 asi sign systems,asi
 asi sign systems inc,asi
 asian chao,asian chao oriental eatery
@@ -252,16 +286,19 @@ assisting hands,assisting hands home care
 asurion tech repair solutions,ubreakifix asurion
 atc healthcare,atc healthcare services
 athena learning center,athena learning centers
+athletic revolution,fitness revolution
 atlanta bread company bakery cafe,atlanta bread
 atthe lb,at the lb
 attibassi,attibassi cafe
 attibassi cafe kiosk,attibassi cafe
 atw0rk,atwork
+atwell,atwell suites
 atwork group,atwork
 atwork medical services,atwork
 atwork personnel services,atwork
 atwork search group,atwork
 au zaatar,au za atar
+au2b building consulting management,au2b
 augmenttm,augment
 augusta lawn care,augusta lawn care services
 aunt millie,aunt millies bakeries
@@ -287,25 +324,28 @@ b organized,2b organized
 bab,big apple bagels
 bab mfm,my favorite muffin
 baby boot camp,karna fitness
+baby boot camp kama fitness,karna fitness
 baby boot camp karna fitness,karna fitness
+baby boot camp korno fitness,karna fitness
 baby boot camp kärna fitness,karna fitness
 bach to rock 5,bach to rock
 bad ass coffee,bad ass coffee hawaii
 baekjeong restaurants,baekjeong
 bagel factory,NA
 bahama buck original shaved ice,bahama bucks original shaved ice
+baja fresh mexican grill,baja fresh
 balloon kings,NA
 bamb shoppes,bambu
-bamb≈´,bambu
-bamb≈´ shoppes,bambu
-bambåª,bambu
-bambåª shoppe,bambu
-bambū,bambu
 bambu desserts and drinks,bambu
 bambu desserts drinks,bambu
 bambu shoppe,bambu
 bambu shoppes,bambu
+bambåª,bambu
+bambåª shoppe,bambu
+bambū,bambu
 bambū shoppes,bambu
+bamb≈´,bambu
+bamb≈´ shoppes,bambu
 bandag dealer agreement,bandag
 bar b cutie smokehouse,bar b cutie
 barbershop salon,barbershop a hair salon for men
@@ -332,15 +372,18 @@ bb.q chicken bistro,bbq chicken
 bbq chicken bistro,bbq chicken
 bds mongolian barbeque,bds mongolian grill
 beard papas freshn natural cream puffs,beard papas
+beard papas sweets cafe,beard papas
 beard papas sweets café,beard papas
 bearfruit jewelry,bearfruit
 beauty supply outlet,beauty full days
+bebalanced hormone weight loss center,bebalanced
 bebalanced hormone weight loss centers,bebalanced
 beef a roo,beefaroo
 beef jerkey outlet,beef jerky experience
 beef o bradys family sports pubs,beef o bradys
 beef obradys,beef o bradys
 beef obradys family sports pub,beef o bradys
+beef obradys family sports pubs,beef o bradys
 beef'o brady's,beef o bradys
 beersauce shop,beersauce
 beeteashop,bee tea
@@ -350,11 +393,12 @@ bellacinos pizza,bellacinos pizza grinders
 ben barketplace,bens barketplace
 ben franklin,ben franklin crafts
 ben jerrys scoop shop,ben jerrys
+ben jerrys scoop shop program,ben jerrys
 ben jerrys special venue scoop shop program,ben jerrys
 ben soft pretzels,bens soft pretzels
-ben’s soft pretzels,bens soft pretzels
 benny restaurants,bennys
 bennys restaurants,bennys
+ben’s soft pretzels,bens soft pretzels
 berlitz kids after school programs,berlitz
 berlitz language centers,berlitz
 berry blendz juice,berry blendz
@@ -377,6 +421,9 @@ big air trampoline,big air trampoline park
 big air trampoline park logo,big air trampoline park
 big apple bagels my favorite muffin,big apple bagels
 big apple bagels my favorite muffin bab mfm,big apple bagels
+big apple bagels my favorite muffin brewsters coffee,big apple bagels
+big apple bagels my favorite muffin sweetduet,big apple bagels
+big apple bagels my favorite muffin sweetduet co brand,big apple bagels
 big apple bagels my favorite muffin sweetduet frozen yogurt gourmet muffins,big apple bagels
 big boy restaurants,big boy
 big boys burgers shakes,big boy
@@ -384,6 +431,7 @@ big fish little fish restaurant,big fish little fish
 big frog,big frog custom t shirts more
 big frog business,big frog custom t shirts more
 big frog custom t shirts,big frog custom t shirts more
+big frog store,big frog custom t shirts more
 big mamas papas pizzerias,big mamas papas pizzeria
 big o bff,big o tires
 big otires,big o tires
@@ -397,6 +445,7 @@ billy sims bbq,billy sims barbecue
 bio blow dry bar,blo blow dry bar
 bio one colorado,bio one
 bishop,bishops
+bishops barbershop,bishops
 bk lobster seafood bars,bk lobster seafood bar
 bl restaurant,NA
 black bear diners,black bear diner
@@ -404,11 +453,14 @@ black dawg,jet black
 blackball outlets,blackball
 blaze fast fired pizza,blaze pizza
 bldg works,bldgworks
+blimpie americas sub shop,blimpie
 blimpie subs,blimpie
 blimpie subs salads,blimpie
+blingle blingle premier lighting,blingle
 blockbuster video superstore,blockbuster
 blow drive,blow drive interlock
 blow dry bar,blo blow dry bar
+blue coast financial group,blue coast financial
 blue grace,blue grace logistics
 blue grace group 25th,blue grace logistics
 blue nose aerial,blue nose
@@ -416,6 +468,7 @@ blue ox,blue nose
 bluegrace logistics,blue grace logistics
 blushington lounge,blushington
 bncks minifigs,bricks minifigs
+bni franchise,bni
 boardwalk fresh burgers fries,boardwalk fries burgers shakes
 boba time smoothie coffee shaved ice,its boba time
 bobi frutii,bobii frutii
@@ -452,6 +505,7 @@ bostons restaurant sports bar,bostons the gourmet pizza restaurant sports bar
 bottomsupespresso,bottoms up espresso
 boulder designs border magic,boulder designs
 bowl heaven sept,bowl heaven
+brain balance achievement centers,brain balance
 brain balance centers,brain balance
 bratworks restaurants,bratworks
 bratworkslemonshark,lemonshark poke
@@ -468,11 +522,13 @@ brilliant sky,brilliant sky toys books
 brilliant sky toys,brilliant sky toys books
 british swim,british swim school
 broadway pizza broadway bar pizza,broadway pizza
+broadway pizza broadway bar pizza broadway pizza express,broadway pizza
 broken egg cafe,broken yolk cafe
 broken yolk café,broken yolk cafe
 bruster real ice cream,brusters real ice cream
 brusters,brusters real ice cream
 bso beauty supply outlet,bso beauty supply express outlet
+bubbas 33 restaurant,bubbas 33
 bubbleology café,bubbleology cafe
 bubbles the color salon standard franchise offering,bubbles the color salon
 buckhorn bbq,buckhorn grill
@@ -489,28 +545,33 @@ buffalo wild wings sports bar,buffalo wild wings
 building kidz,building kidz school
 buildingstars new york,buildingstars
 bum boot camp,burn boot camp
+bumperdoc express auto body repair centers,bumperdoc
 bumtobox,burritobox
-bünda,bunda
-bündä,bunda
 bundy american,rent a wreck
 burgenm,burgerim
 burger exotic village burger village,burger exotic village
 burger king restaurant,burger king
+burger king restaurant franchise agreement,burger king
 burrito blvd,burrito bar
 business coach,business card holder
 business partner marketing coach,business partner
+butterfli me makeup lash studio,butterfli me
 butterfli me studio,butterfli me
+bw premier collection,best western hotels resorts
 bw premier collection bw signature collection,best western hotels resorts
 bw signature collection,best western hotels resorts
-bw premier collection,best western hotels resorts
 bww go,buffalo wild wings
+bünda,bunda
+bündä,bunda
 c12,c12 group
 c3 wellness,c3 wellness spa
-café 86,cafe 86
 caffebene stores,caffebene
+café 86,cafe 86
 caiexico,calexico
 calc,clean air lawn care
+calexico taqueria,calexico
 cali coffee,NA
+caliburger caliburger,caliburger
 california closet,california closets
 callburger,caliburger
 cambria,cambria hotels
@@ -519,9 +580,11 @@ cambria suites,cambria hotels
 camille albane paris,camille albane
 camp bow wow home buddies,camp bow wow
 camp gladiator,cg growth
+candlewood,candlewood suites
 candy bouquet development document,candy bouquet
 candy bouquet franchise development document,candy bouquet
 canning senior service,caring senior service
+canopy by hilton,canopy hilton
 canteen vending services,canteen
 canteen vending services division,canteen
 cap college admission plan,college admission plan
@@ -544,9 +607,11 @@ carrows restaurants,carrows restaurant
 carstar auto body repair experts,carstar
 cartndge world,cartridge world
 "cartridge world midwest, llc",cartridge world
+carvel ice cream shoppe,carvel
 celebree,celebree school
 celebrity soul food,celebritys soul food
 cellains,cellairis
+cellairis mall units,cellairis
 center point medicine (cpm),center point medicine
 central bark doggy day care,central bark
 certa pro,certapro painters
@@ -555,6 +620,7 @@ certified restoration dry cleaning network,NA
 certified restoration dry cleaning network llc,NA
 cg,cg growth
 championship martial arts,champions martial arts center
+charles schwab independent branch,charles schwab
 charlesschwab,charles schwab
 charleys cheesesteaks wings,charleys
 charleys grilled subs,charleys
@@ -570,30 +636,45 @@ checkers rallys restaurants,checkers
 checkers restaurant,checkers
 checkers restaurant or rally restaurant,checkers
 checkers restaurant or rallys restaurant,checkers
+checkers restaurant rallys restaurant,checkers
 chef it up chef it up 2 go,chef it up
 chem dry carpet drapery upholstery cleaning,chem dry
 chem dry carpet upholstery cleaning,chem dry
 chemdry,chem dry
+cheong kwan jang korea ginseng store,cheong kwan jang
 cherry blow dry,cherry blow dry bar
 chester,chesters
+chevron branded marketer,chevron
+chevron motor fuels,chevron
+chevron or texaco,chevron
+chevron or texaco motor fuel marketer,chevron
+chevron texaco motor fuel,chevron
 chevron texaco motor fuel marketer,chevron
+chevron usa inc chevron texaco motor fuel marketer,chevron
 chicago pizza with twist,chicagos pizza
 chicagos pizza with a twist,chicagos pizza
 chick fil a restaurant,chick fil a
-chick’ncone,chickncone
 chickpea restaurant,chickpea
+chick’ncone,chickncone
 chicos tacos,chicos
 children music academy,childrens music academy
 children orchard,childrens orchard
-children’s orchard,childrens orchard
 childrens magnet montessori,childrens magnet montessori school
+children’s orchard,childrens orchard
 chilis grill bar,chilis
+chilis grill bar chilis special venue,chilis
+chilis grill bar chilis special venue chilis smalltown prototype,chilis
+chip cookies,chip
 chiropractic place,chiropractic
 chock cafe,chock full onuts
 chock cafe segafredo zanetti espressocaf,chock full onuts
 chock full o nuts,chock full onuts
+chock full o nuts chock cafe segafredo zanetti espresso sze cafe,chock full onuts
+chock full o nuts chock cafe sze cafe segafredo zanetti espresso,chock full onuts
+chock full onuts chock cafe segafredo zanetti espresso sze cafe,chock full onuts
 choice,NA
 chop,chopd
+chopvalue micro factory,chopvalue
 christian brothers,christian brothers automotive
 christie’s international real estate,christies international real estate
 chrome tacos,chronic tacos
@@ -611,16 +692,20 @@ city acupuncture new york,city acupuncture
 city looks salons,city looks
 city looks salons international,city looks
 city publications group,city publications
+city sports marketing group,city sports marketing
 city sweats spa,city sweats
 city wide facility solutions,city wide
 city wide maintenance,city wide
 cityrow fitness,cityrow
 clarion,clarion choice hotels
 clarion agreement,clarion choice hotels
+clarion clarion pointe,clarion choice hotels
 clarion hotel,clarion choice hotels
 classic rock coffee colorado,classic rock coffee
+classy closets classy kitchen bath,classy closets
 clean auth,cleaning authority
 clean your dirty face air,clean your dirty face
+cleanest restaurant group,cleanest restaurant
 cleaning auth,cleaning authority
 cleannet baltimore washington,cleannet
 cleannet illinois,cleannet
@@ -634,7 +719,9 @@ club z in home tutoring services,club z in home tutoring
 club zl,club z in home tutoring
 cmit sol,cmit solutions
 coast,coast hotels
+coast supply,coast hotels
 cobblestone inn suites cobblestone hotel suites,cobblestone inn suites
+cobblestone inn suites cobblestone hotel suites cobblestone suites,cobblestone inn suites
 cobblestone inn suites or cobblestone hotel suites,cobblestone inn suites
 cobblestone lodging facilities,cobblestone hotel suites
 coco bakery restaurant,cocos bakery restaurants
@@ -644,11 +731,14 @@ code fu,codefu
 coffee bay stores,coffee bay
 coin postal,goin postal
 coit,coit cleaning restoration services
+coit core services,coit cleaning restoration services
 coit drapery carpet cleaners,coit cleaning restoration services
 colbie's southern kissed chicken,colbies southern kissed chicken
 coldwell banker commercial,coldwell banker
+coldwell banker commercial affiliates,coldwell banker
 coldwell banker residential affiliates,coldwell banker
 cole backyard grill,coles backyard grill
+coles bakery coles bakery cafe,coles
 college hunks,college hunks hauling junk
 college hunks hauling junk college hunks moving,college hunks hauling junk
 college hunks hauling junk moving,college hunks hauling junk
@@ -670,10 +760,14 @@ comforcare senior services,comforcare home care
 comfort comfort inn suites,comfort
 comfort dental braces,comfort dental
 comfort inn comfort inn suites,comfort
+comfort inn comfort inn suites comfort suites,comfort
+comfort inn comfort inn suites or comfort s ui tes,comfort
 comfort inn comfort inn suites or comfort suites,comfort
 comfort inn comfort suites comfort inn suites,comfort
 comfortkeepers,comfort keepers
 comic book café,comic book cafe
+commercial investors group,commercial investors
+commonwealth care group,commonwealth care
 compass margaritaville hotels resorts,compass margaritaville
 complete kitchen tune up,kitchen tune up
 compuchild services of america,compuchild
@@ -683,16 +777,19 @@ concierge outdoor,concierge outdoor services
 concrete raising america,concrete craft
 conquer ninja gym,conquer ninja
 conquer ninja gyms,conquer ninja
+conrad hotels,conrad hotels resorts
 conroys,1 800 flowers
+conroys flowers,1 800 flowers
 contender esports gaming center,212 contender esports gaming center
 cook tortas,cooks tortas
-cook’s tortas,cooks tortas
 cookie dough café,cookie dough cafe
 cookies design cookie bouquet,cookies design
+cook’s tortas,cooks tortas
 cool hand luke steakhouse saloon,cool hand lukes steakhouse saloon
 coolvu,coolvu glass surface solutions
 corkys,corkys ribs bbq
 cornwell,cornwell quality tools
+corporate cleaning group,corporate cleaning
 corvus,corvus janitorial
 cost cutters,cost cutters family hair salon
 cost cutters family hair care,cost cutters family hair salon
@@ -715,21 +812,30 @@ cover all,coverall
 coverall cleaning concepts,coverall
 coverall health based cleaning,coverall
 coverall indianapolis,coverall
+coverall janitorial,coverall
 coverall mountain pacific,coverall
 coverall of the twin cities,coverall
 coverall service,coverall
+coverall the twin cities,coverall
 coverall twin cities,coverall
+coverall washington,coverall
 cpr cell phone repair,cell phone repair
 crdn certified restoration drycleaning network,NA
-créatif,creatif
+crdn the textile experts,crdn
 creative tots,NA
 creative world schools,creative world school
 crepe de licious,crepe delicious urban cafe
 crepe delicious,crepe delicious urban cafe
+crescendo vom fass oils vinegars spices,crescendo
+crestcom area representative,crestcom
+crestcom business,crestcom
 crestcom executive program,crestcom
 crittercontrol,critter control
 crooked pint ale house restaurant,crooked pint ale house
+crowne plaza crowne plaza crowne plaza suites crowne plaza resort,crowne plaza
+crowne plaza crowne plaza suites crowne plaza resort,crowne plaza
 crowne plaza hotels resorts,crowne plaza
+crs packout,crs
 cruise one,cruiseone
 cruise plan,cruise planners
 cruise planners american express,cruise planners
@@ -741,6 +847,7 @@ crunch fitness,crunch
 crunch health club,crunch
 cruncheese,crunch
 crushed red urban bake chop shop,crushed red
+créatif,creatif
 csg,cheesy street grill
 culver,culvers butterburgers frozen custard
 culvers,culvers butterburgers frozen custard
@@ -748,9 +855,12 @@ cune leammg,curie learning
 curie learning center,curie learning
 curio,curio collection hilton
 current meditation studio,current meditation
+currentsafe home electrical services,currentsafe
+curves co brand curves jenny craig,curves
 curves for women,curves
 curves jenny craig,curves
 curves jenny craig brand,curves
+curves jenny craig co brand,curves
 cuts fitness for men,cuts fitness for women
 d bat academies,d bat
 d spot dessert café,d spot dessert cafe
@@ -767,8 +877,11 @@ dale carneg,dale carnegie
 dale carnegie training,dale carnegie
 dalecarneg,dale carnegie
 days inn,days inn wyndham
+days inn days hotel days inn suites,days inn wyndham
 dcap insurance tax zone,dcap insurance
 decor coach,decor you
+decor coach franchise styleprint decor designer franchise decor you,decor you
+decor coach styleprint decor designer,decor you
 decor you designer unit,decor you
 decorating den,decorating den interiors
 delivery com,deliverycom
@@ -795,11 +908,17 @@ disaster kleenup dki,dki
 discoverymap,discovery map
 dk,dki
 dner gyros hub,doner gyros hub
+doan group,the doan
 doctors express,american family care
 doctors express sept,american family care
+doctors express urgent care,american family care
 dog haus restaurants,dog haus
 dog junk removal hauling,jdog junk removal hauling
 dog wizard academy,dog wizard
+dolce hotels,dolce
+dolce hotels resorts,dolce
+dolce hotels resorts wyndham,dolce
+dolce wyndham,dolce
 dollar,dollar rent a car
 dollar dollar rent a car,dollar rent a car
 dollar or dollar rent a car,dollar rent a car
@@ -808,18 +927,20 @@ dollars inside business,dollars inside
 dolly llama shops,dolly llama
 dollyllamashops,dolly llama
 donatos,donatos pizza
-döner gyros hub,doner gyros hub
 doner kebab outlet,doner kebab
 doodle bugs childrens learning academy,doodle bugs
 dos coyotes,dos coyotes border cafe
 dos coyotes restaurants,dos coyotes border cafe
 doubletree,doubletree hilton
 doubletree hotels suites resorts,doubletree hilton
+downsize fitness weight loss centers,downsize fitness
 downtowner,downtowner inns
 dq,dq grill chill
 dq orange julius,dq grill chill
+dq treat franchise program,dq treat
 dreammaker,dreammaker bath kitchen
 dreammaker bath kitchen worldwide,dreammaker bath kitchen
+dripp coffee bar,dripp
 drybar shop,drybar
 drymedic,drymedic restoration services
 duan chun zhen beef noodle,duan chun zhen
@@ -830,7 +951,11 @@ dumpstor,dumpster dudez
 dunn bros coffee,dunn brothers coffee
 dura clean,duraclean
 duraclean fabric specialist,duraclean
+duraclean fabric specialist cleaning restoration,duraclean
+duraclean fabric specialist franchise duraclean cleaning restoration,duraclean
+duraclean restoration cleaning,duraclean
 dutch bros,dutch bros coffee
+döner gyros hub,doner gyros hub
 e young engineers,e2 young engineers
 e3 clinic e3 elite rehab,e3 elite rehab
 eagle tax,eagletax
@@ -844,6 +969,10 @@ east elite rehab,e3 elite rehab
 easyvetclinic,easyvet
 eat frog fitness etf fitness,eat the frog fitness
 eat gather love,eatgatherlove
+echo suites,echo suites extended stay wyndham
+echo suites mb,echo suites extended stay wyndham
+echo wyndham,echo suites extended stay wyndham
+econo lodge econo lodge inn suites,econo lodge
 econo lub n tune,econo lube n tune brakes
 econo lube n tune brakes centers,econo lube n tune brakes
 econo lube n'tune & brakes,econo lube n tune brakes
@@ -851,9 +980,13 @@ econo lube ntune,econo lube n tune brakes
 econolodge,econo lodge
 edgurukul,ed gurukul
 egg bird,egg n bird
+egg i am,egg i
+egg i restaurant the egg i am restaurant,egg i
+egg i restaurants incl the egg i am restaurant,egg i
 eggholic restaurant,eggholic
 egoscue institute,egoscue method
 egoscue university,egoscue method
+egoscue university institute,egoscue method
 eighteen eight salons,18 8
 einstein bros,einstein pros
 einstein bros restaurant,einstein bros bagels
@@ -866,13 +999,20 @@ elmer's breakfast-lunch-dinner restaurant,elmers breakfast lunch dinner
 elmers breakfast egg n joe,egg n joe
 elmers breakfast elmers kitchen egg n joe,egg n joe
 elmers breakfast lunch dinner egg n joe,elmers breakfast lunch dinner
+elmers breakfast lunch dinner restaurant egg n joe restaurant,elmers breakfast lunch dinner
+elmers breakfast lunch dinner restaurant egg n joe restaurant elmers kitchen,elmers breakfast lunch dinner
+elmers breakfast lunch dinner restaurant egg n joe restaurant elmers kitchen breakfast brunch mimosa,elmers breakfast lunch dinner
+elmers breakfast lunch dinner restaurant egg n joe restaurant elmers kitchen breakfast brunch mimosas,elmers breakfast lunch dinner
+elmers breakfast lunch dinner restaurant elmers kitchen egg n joe restaurant,elmers breakfast lunch dinner
 embassy suites,embassy suites hilton
 embassy suites hotels,embassy suites hilton
 embriodme,fully promoted
 embroidme,fully promoted
 en vie fitness,envie fitness
+energy wellness,energy
 engel & völkers yachting brokerage,engel volkers yachting
 engel vdlkers,engel volkers
+engel volkers residential real estate brokerage,engel volkers
 engel völkers,engel volkers
 engel völkers residential real estate brokerage,engel volkers
 engel völkers yachting,engel volkers yachting
@@ -892,18 +1032,23 @@ era franchise,era real estate
 erbert gerberts sandwich shops,erbert gerberts sandwich shop
 erbert gerberts subs club,erbert gerberts sandwich shop
 erc expense reduction coaching,expense reduction coaching
+ers restoration specialties,ers
 espressamente illy,illy caffe
 essential brands,essential pros
+estate group,estate
 etm studio,elements massage
 evans,evans garment restoration
+everhome,everhome suites extended stay choice hotels
 everhome suites,everhome suites extended stay choice hotels
 executive care,executive home care
 executive care your home care,executive home care
 executive image,executive home care
+exit factor,exit
 exit offering,exit
 exit realty corp,exit
 exit realty pacific west,exit
 exit realty virginia,NA
+exit subfranchise,exit
 expedia cruiseshipcenters,expedia cruises
 expense reduction,expense reduction analysts
 expense reduction analysts era,expense reduction analysts
@@ -915,6 +1060,7 @@ express pros,express employment professionals
 express services,express employment professionals
 express tax,expresstax
 extra innings sports center,extra innings
+extra innings training center,extra innings
 extra innings training centers,extra innings
 eye level,eye level learning center
 eye level learning centers,eye level learning center
@@ -927,12 +1073,14 @@ faces365 spas,faces365 spa
 fairfield inn fairfield inn suites,fairfield marriott
 fairfield inn fairfield inn suites marriott,fairfield marriott
 fairfield inn suites,fairfield marriott
+fairfield inn suites marriott,fairfield marriott
 fairway divorce solutions,fairway divorce
 falafel comer,falafel corner
 family dollar,NA
 family financialcenters,family financial centers
 family medicine plus,family med plus
 famous famiglia,famous famiglia pizzeria
+famous famiglia restaurant,famous famiglia pizzeria
 fantastic sams cut color,fantastic sams
 fantastic sams hair salons,fantastic sams
 fantastic sams salons,fantastic sams
@@ -955,6 +1103,7 @@ fatburger north american,fatburger
 fatburger restaurants,fatburger
 fatima grill,fatimas grill
 fazoli,fazolis
+fazolis franchising,fazolis
 fdd gurus education,gurus education
 fiesta,fiesta insurance
 fiesta auto ins,fiesta insurance
@@ -962,14 +1111,19 @@ fiesta auto insurance tax,fiesta insurance
 fiesta ins,fiesta insurance
 figaros,figaros pizza
 figaros italian pizza figaros nick n willys,nick n willys
+figaros italian pizza inc nick n willys,nick n willys
+figaros italian pizza inc nick n willys figaros nick n willys,figaros pizza
 figaros italian pizza nick n willys,nick n willys
 figaros nick n willys,figaros pizza
 filta,filta environmental kitchen solutions
+filta fry,filta environmental kitchen solutions
 filta fry agreement,filta environmental kitchen solutions
 fire ice,fire ice interactive grill bar
+fire ice restaurant,fire ice interactive grill bar
 firehouse,firehouse subs
 firehouse subs restaurants,firehouse subs
 firenza pizza,firenza
+firestorm predict plan perform,firestorm
 firkin group pubs,firkin pubs
 firm business coach,actioncoach
 first choice haircutters,first choice business brokers
@@ -1003,6 +1157,7 @@ flippin pizza new york style,flippin pizza ny pies slices
 flips store,flips
 floor covering,floor coverings
 floor coverings int,floor coverings
+floor trader carpet floors,floor trader
 flooramericas choice in floor fashions,abbey carpet floor
 floorcoverings int,floor coverings
 flour power,flour power cooking studios
@@ -1030,21 +1185,27 @@ four points,four points sheraton
 four points hotels,four points sheraton
 four seasons sunrooms,four seasons sunrooms greenhouse
 fractured prune doughnuts,fractured prune
+franchise development group,development group
 frankseoul,frankseoul korean fried snack cafe
+frankseoul restaurants,frankseoul korean fried snack cafe
+frannet business,frannet
 franserve,NA
 fred astaire franchised dance studio,fred astaire dance studios
 freddys frozen custard,freddys frozen custard steakburgers
+french table gastropub creperie,french table
 french table restaurant creperie,french table
-fresln,fresh
+fresh asian grill,fresh
 fresh coat painters,fresh coat
 fresh healthly with my comments,fresh healthy vending
 fresh healthy,fresh healthy cafe
+fresh monkee,fresh
 fresh to order (f2o),fresh to order
 fresh to order fresh 2 order f,fresh to order
 freshberry natural frozen yogurt,freshberry
 freshcoat,fresh coat
 freshii restaurant,freshii
 freshway,fresh
+fresln,fresh
 friendly computers,friendly computers mobile computer services
 friendship foods,friendship foods bbq
 frontier adj,frontier adjusters
@@ -1057,25 +1218,31 @@ fruit bouquets,1 800 flowers
 fruit cup,snowfruit
 fruitfull frozen fruit bars,fruitfull
 fruttfull,fruitfull
+fs8 studio,fs8
 fsbohomes,fsbohomescom
 fuchsia spa,fuchsia
 fudruckers,fuddruckers
 fujisan asian bar,fujisan
 fujisan asian bar service kiosk,fujisan
+full psycle full body indoor cycling,full psycle
 fully promoted embroidme,fully promoted
 fun bus fitness fun on wheels,fun bus
 fuwa fuwa,fuwa fuwa japanese pancakes
+fuwa fuwa pancakes,fuwa fuwa japanese pancakes
 fuzziwig candy factory,fuzziwigs candy factory
 fuzzy’s taco shop®,fuzzys taco shop
 g star,g star raw
 gafe,tbaar
 gallaghers restaurant,gallaghers
+gallaghers steak house,gallaghers
 gamp transformation center,camp transformation center
 gandolfos,gandolfos deli
 gandolfos new york delicatessen,gandolfos deli
 garageexperts,garage experts
 garbanzo mediterranean fresh restaurant,garbanzo mediterranean fresh
 garbanzo mediterranean grill,garbanzo mediterranean fresh
+garner ihg hotel,garner
+garner ihg hotel brand,garner
 gattis pizza,mr gattis pizza
 gecko hospitality gecko executive hospitality,gecko hospitality
 geeks on call america,geeks on call
@@ -1089,6 +1256,7 @@ getfried,getfried fry cafe
 gforce,g force
 gh builders ny,gh
 ghana bros,ohana bros
+ghana bros island style shave ice fries chips popcorn,ohana bros
 ghost kitchen,ghost kitchens
 gina maria's,gina marias pizza
 giordanos restaurants,giordanos
@@ -1107,6 +1275,7 @@ gloriajeanscoffees,gloria jeans coffees
 glowzone arena,glowzone
 gnc,gnc live well
 gnc livewell,gnc live well
+go airport shuttle the go group go,go airport shuttle
 go bumto,go burrito restaurant
 go burrito,go brit
 go greek yogurt shops,go greek yogurt
@@ -1128,17 +1297,22 @@ golden krust caribbean bakery grill,golden krust caribbean restaurant
 golden krust caribbean restaurants,golden krust caribbean restaurant
 golden spoon frozen yogurt,golden spoon
 golds gym express,golds gym
+golf envy,golf
 golf etc america,golf etc
 golftec improvement center,golftec
 gomobile tires gomobile detail,gomobile tires
+gong cha us master,gong cha
 goobne chicken,goobne
 good,bgood
 good burger,NA
 good citizen dog,good citizen dog peaceful living with your dog
+good citizen dog training,good citizen dog peaceful living with your dog
 good citizen dog training peaceful living with your dog,good citizen dog peaceful living with your dog
 good feet,good feet store
 good neighbor pharmacy gnp premier pharmacy,good neighbor pharmacy
+goodcents area representative,goodcents
 goodcents deli fresh subs,goodcents
+goodcents deli subs,goodcents
 goodcents restaurant,goodcents
 goodcents subs,goodcents
 goosehead,goosehead insurance
@@ -1149,6 +1323,8 @@ gradepower,gradepower learning
 grand rental station taylor rental,grand rental station
 grandmaster samane's pro martial arts karate studio,grandmaster samanes pro martial arts karate
 grandstay residential suites,grandstay
+grandstay residential suites crossings grandstay grandstay hotel conference center grandstay hotel suites,grandstay
+grandstay residential suites crossings grandstay inn suites grandstay hotel conference grandstay hotel suites,grandstay
 grasons estate sale services,grasons
 grasons estate sales services,grasons
 gravity drive thrus,gravity
@@ -1159,6 +1335,7 @@ gravity vault indoor rock gyms,gravity vault indoor rock gym
 great american cookie,great american cookies
 great american insurance,NA
 great harvest bread,great harvest bakery cafe
+great harvest bread company bakery cafe,great harvest bakery cafe
 great harvest bread company bakery café,great harvest bakery cafe
 great khan,great khans mongolian grill
 great khan mongolian grill,great khans mongolian grill
@@ -1175,18 +1352,21 @@ green mill restaurant,green mill restaurant bar
 greene turtle sports bar grille,greene turtle
 greenhomes,greenhomes america
 greentree inn hotel,greentree inn
-grégoire,gregoire
 grimaldis,grimaldis coal brick oven pizzeria
+grimaldis restaurant,grimaldis coal brick oven pizzeria
 griswold homecare,griswold home care
 griswold special care,griswold home care
 grn,global recruiters network
 grn global recruiters,global recruiters network
 grn global recruiters network,global recruiters network
 groombar by earthwise pet,earthwise pet
+groombar earthwise pet earthwise pet,earthwise pet
+groombar earthwise pet earthwise pet dee o gee earthwise pet,earthwise pet
 groovy hues,groovy hues peace love paint powerwash
 growler,growler guys
 growleru,growler guys
 growthcoach,growth coach
+grégoire,gregoire
 gus world famous fried chicken,guss world famous fried chicken
 guys place salon or barbershop salon,barbershop a hair salon for men
 gymboree,gymboree play music
@@ -1195,12 +1375,10 @@ gyu kaku japanese bbq restaurant,gyu kaku
 h 1 auto care,honest 1 auto care
 h salt fish chips shoppe,h salt fish chips
 h u m a n human healthy vending,NA
-häagen dazs,haagen dazs
 haagen dazs shop,haagen dazs
-häagen dazs shop,haagen dazs
 haagen dazs shoppe,haagen dazs
-häagen dazs shoppe,haagen dazs
 habit burger,habit burger grill
+habit burger restaurant,habit burger grill
 hair club,hairclub
 haircuts for kids,cookie cutters haircuts for kids
 haircuts for men,knockouts
@@ -1218,6 +1396,7 @@ hand stone,hand stone massage facial spa
 hand stone massage,hand stone massage facial spa
 handel's homemade ice cream & yogurt,handels homemade ice cream
 handman matters,ace handyman services
+handyman group,handyman
 handyman matter,ace handyman services
 handyman matters,ace handyman services
 handypro handyman services,handypro
@@ -1226,13 +1405,16 @@ hanshin pocha noodle j 1,hanshin pocha
 happy healthy,fruitfull
 happy nails spa,happy nails
 happyandhealthy,fruitfull
+harcourts northwest,harcourts
 harcourts real estate,harcourts
 harcourts real estate brokerage,harcourts
+harcourts real estate brokerage offices,harcourts
 hard exercise works center,hard exercise works
 hard rock hotels,hard rock hotel
 hardcore fitness,hardcore fitness boot camp
 hardware hank trustworthy hardware golden rule lumber center,hardware hank
 hawkinson,hawkinson tread service
+hawkinson tire retreading,hawkinson tread service
 hawthorn,hawthorn extended stay wyndham
 hawthorn suites wyndham,hawthorn extended stay wyndham
 health atlasts,health atlast
@@ -1248,24 +1430,31 @@ heart caregiver services,1heart caregiver services
 heathsource,healthsource chiropractic
 heaven best,heavens best
 heaven heights,heaven heights senior care
-heaven’s best,heavens best
 heavens best carpet uphol cleaning,heavens best
 heavens best carpet upholstery cleaning,heavens best
+heavens best subfranchise,heavens best
+heaven’s best,heavens best
 help sell real estate,help u sell
 help u sell real estate,help u sell
 hertz car rental,hertz
 hertz rent a car,hertz
 heuk hwa dang outlets,heuk hwa dang
 hi five sports club,hi five sports
+hi five sports club hi five sports zone,hi five sports
 hi five sports clubs,hi five sports
+hi five sports clubs hi five sports zone,hi five sports
 hiccups restaurant,hiccups restaurant teahouse
+hilda demirjian laser skin care,hilda demirjian
 hilton,hilton hotels resorts
 hilton garden inn canada,hilton garden inn
 hirequest direct,hirequest
 hissho asian kitchen,hissho sushi
 hissho food outlet,hissho sushi
 hissho or oumi,hissho sushi
+hissho sushi aoeumi sushi or sushi with gusto,hissho sushi
+hissho sushi aoeumi sushi sushi with gusto,hissho sushi
 hissho sushi oumi,hissho sushi
+hissho sushi oumi sushi sushi with gusto,hissho sushi
 hissho sushi sushi with gusto oumi sushi,hissho sushi
 hnj restaurant,hot n juicy crawfish
 hnr tire express,rnr tire express
@@ -1275,8 +1464,12 @@ hobby town usa hobby,amain performance hobbies
 hobbytown hobbytown,hobbytown
 hokuha,hokulia
 hokulia shave ice,hokulia
+holiday inn brand including holiday inn express holiday inn suites holiday inn resort,holiday inn
+holiday inn express,holiday inn
 holiday inn holiday inn express,holiday inn
+holiday inn holiday inn express holiday inn express suites holiday inn resort,holiday inn
 holiday stationstores,holiday stationstore
+holtorf medical group,holtorf medical
 home 2 suites hilton,home2 suites hilton
 home care advocacy network,homecare advocacy network
 home care assistance,home care assistance 1 866 4 livein
@@ -1293,18 +1486,24 @@ home smart,homesmart
 home team,hometeam inspection service
 home team inspec,hometeam inspection service
 home vestors,homevestors
+home2 suites,home2 suites hilton
 homecare assistance,homecare america
 homecleaning,home cleaning centers america
 homekeepr,homekeepers
 homes land estates homes,estates homes
 homes land magazine,homes land
+homesmart international real estate brokerage,homesmart
 homesmiles,homesmilescom
 hometask handyman service,hometaskcom handyman services
 hometeam,homesteady
 hometeam inspec,hometeam inspection service
+hometowne,hometowne studios red roof
+hometowne studios,hometowne studios red roof
+hometowne studios red roof brand family hometowne studios red roof hometowne studios suites red roof hometowne inn hometown inn,hometowne studios red roof
 homevestors america,homevestors
 homewatch,homewatch caregivers
 homewell senior care,homewell care services
+homewood suites,homewood suites hilton
 hommati network,hommati
 honest 1,honest 1 auto care
 honest 1 auto care center,honest 1 auto care
@@ -1313,6 +1512,7 @@ honest restaurant,honest
 honest1 auto care,honest 1 auto care
 honey baked ham,honeybaked ham
 honey baked ham cafe,honeybaked ham
+honey baked ham co cafe,honeybaked ham
 honeybaked ham cafe,honeybaked ham
 honeybaked ham café,honeybaked ham
 honeycuts hair salon,honeycuts
@@ -1323,12 +1523,14 @@ hot dog on stick,hot dog on a stick
 hot stuff foods,hot stuff pizza
 hotel rl,hotel rl red lion
 hotshots,hotshots sports bar grill
+house bread bakery cafe,house bread
 house doc,house doctors
 house doctors handyman service,house doctors
 house master,housemaster
 house of bread bakery cafe,NA
 house trix,defy
 housemaster home inspections,house call home inspection
+howard johnson,howard johnson wyndham
 howdy homemade,howdy homemade ice cream
 hq gastropub,hq burgers beer music art
 huckleberry,huckleberrys
@@ -1336,21 +1538,26 @@ huhot,huhot mongolian grill
 hui lau shan shop,hui lau shan
 human bean drive thru,human bean
 human healthy markets,human
+human human healthy vending,human
 humble donut,humble donuts
-huntington learning centers,huntington learning center
 hungry howies pizza,hungry howies
+huntington learning centers,huntington learning center
+huntington school services,huntington learning center
 hurricane grill wings 6 7,hurricane grill wings
+hurricane grill wings hurricane burgers tacos wings,hurricane grill wings
 hvpoxi,hypoxi
 hvpoxihypoxi,hypoxi
 hyatt house hotels,hyatt house
 hyatt place hotels,hyatt place
 hydrex,hydrex pest control
+häagen dazs,haagen dazs
+häagen dazs shop,haagen dazs
+häagen dazs shoppe,haagen dazs
 i heart caregiver services,1heart caregiver services
-I heart caregiver services,1heart caregiver services
 i heart mac cheese,i heart mac cheese more
 i love kickboxing,ilovekickboxing
 i milky,imilky
-i’milky,imilky
+i4 search group,i4 search
 i8 8,18 8
 i9 sports complete 8 copy,i9 sports
 ice born,iceborn
@@ -1360,16 +1567,18 @@ idea lab kids,idea lab
 ident a kid services america,ident a kid
 idolize spa,idolize brows beauty
 ifar ifixandrepair,ifixandrepair
+ifg 50 50 program the interface financial group,interface financial group ifg 50 50
 ifixandrepair (ifar),ifixandrepair
 "ignition interlock service centers of california, inc.",ignition interlock service centers ca
 iheart caregiver services,1heart caregiver services
 ihop international house pancakes,ihop
 iinterstate all battery center,interstate all battery center
 illy,illy caffe
-illy caffé,illy caffe
 illy caffè,illy caffe
+illy caffé,illy caffe
 ilovekickboxingcom,ilovekickboxing
 im x pilates,im x
+im x pilates fitness,im x
 im x pilates studio,im x
 im x pilates studios,im x
 image 360,image360
@@ -1383,6 +1592,7 @@ india bazaar indiaco,india bazaar
 indigo joes sports pub restaurant,indigo joes
 ini view,in1view
 ini view real estate business photography,in1view
+inka franchise corp inka express inka wasi el pollo inka,inka
 innovative roofing solutions,innovative roof solutions
 inspect it first,inspect it 1st
 instant tax service,NA
@@ -1404,6 +1614,8 @@ interstate batter,interstate all battery center
 interstate battery,interstate all battery center
 interstate battery franchising,interstate all battery center
 inxpress innovative freight so,inxpress
+irr residential,accurity valuation
+irr-residential,accurity valuation
 isold it on ebay,isold it
 isoldit,isold it
 it s boba time,its boba time
@@ -1413,6 +1625,7 @@ its a grind,its a grind coffee house
 ivan ramen restaurant,ivan ramen
 ivy kids,ivy kids early learning center
 izsain,izsam
+i’milky,imilky
 j d byrider,byrider
 j dog junk removal haulmg,jdog junk removal hauling
 j gilbert's wood-fired steaks & seafood restaurant,j gilberts wood fired steaks seafood
@@ -1430,15 +1643,35 @@ jakes wayback burgers,jakes
 james,james hotels
 jameson inn & suites,jameson inn
 jan pro,jan pro cleaning disinfecting
+jan pro central coast,jan pro cleaning disinfecting
 jan pro cleaning,jan pro cleaning disinfecting
 jan pro cleaning systems central coast,jan pro cleaning disinfecting
+jan pro cleaning systems minneapolis,jan pro cleaning disinfecting
 jan pro cleaning systems ontario,jan pro cleaning disinfecting
+jan pro cleaning systems puget sound,jan pro cleaning disinfecting
+jan pro cleaning systems sacramento,jan pro cleaning disinfecting
+jan pro cleaning systems san diego,jan pro cleaning disinfecting
+jan pro cleaning systems san diego riverside,jan pro cleaning disinfecting
 jan pro cleaning systems san francisco,jan pro cleaning disinfecting
+jan pro cleaning systems silicon valley,jan pro cleaning disinfecting
+jan pro commercial cleaning,jan pro cleaning disinfecting
+jan pro commercial cleaning disinfecting,jan pro cleaning disinfecting
+jan pro development long island,jan pro cleaning disinfecting
+jan pro development puget sound,jan pro cleaning disinfecting
+jan pro franchising,jan pro cleaning disinfecting
+jan pro northern illinois,jan pro cleaning disinfecting
+jan pro northwest,jan pro cleaning disinfecting
 jan pro ontario,jan pro cleaning disinfecting
 jan pro sacramento,jan pro cleaning disinfecting
+jan pro san francisco,jan pro cleaning disinfecting
+jan pro the west,jan pro cleaning disinfecting
 jan pro west,jan pro cleaning disinfecting
+jani king california,jani king
+jani king green bay,jani king
 jani king illinois,jani king
+jani king milwaukee,jani king
 jani king minnesota,jani king
+jani king western washington,jani king
 jani-king,jani king
 janiking,jani king
 janpro,jan pro cleaning disinfecting
@@ -1447,8 +1680,10 @@ jaws topokki outlets,jaws topokki
 jazzercise dance fitness program,jazzercise
 jd byrider,byrider
 jd byrider cnac carnow acceptance,byrider
+jd byrider cnac carnow acceptance co cnac,byrider
 jdog carpet cleaning,jdog carpet cleaning floor care
 jdog junk,jdog junk removal hauling
+jdv,jdv hyatt
 jei self learning,jei learning center
 jei self learning centers,jei learning center
 jerry wood fired dogs,jerrys wood fired dogs
@@ -1462,16 +1697,21 @@ jimmy johns gourmet sandwich shops,jimmy johns
 jimmy johns gourmet sandwiches,jimmy johns
 jimmy johns sandwiches,jimmy johns
 jinya ramen bars,jinya ramen bar
+jj s candy em,schwieterts cones candy
+jjs candy em,schwieterts cones candy
 jlitutoring,tutoring club
 john casablancas modeling career center,john casablancas centers
 john casablancas modeling career center model talent management agency,john casablancas centers
 john casablancas modeling career centers,john casablancas centers
 john farley art supplies,jack farleys art supplies
 john l scott,john l scott real estate
+johnny brusco s new york style pizza,johnnys new york style pizza
+johnny bruscos new york style pizza,johnnys new york style pizza
 johnny quik,johnny quik food store
 johnny rockets group,johnny rockets
 johnny rockets restaurant,johnny rockets
 johnny's italian steakhouse restaurants,johnnys italian steakhouse
+johnston tate wealth advisory group,johnston tate wealth advisory
 johnstone,johnstone supply
 jojo grill dog,jojos grill a dog
 joshua tree experts,joshua tree
@@ -1481,19 +1721,25 @@ jump zone,jump on in
 jumpzone,jumpzone party play centers
 jumpzone party centers,jumpzone party play centers
 junk shot doorstep details,doorstep details
+junkluggers luggers moving,luggers moving
 just between,just between friends
 jw marriott,marriott hotels
+jw marriott hotel,marriott hotels
 kaia f i t,kaia fit
 kaia f.lt.,kaia fit
 kajiken restaurant,kajiken
 kalologie spa,kalologie 360 spa
+kalologie spa destinations llc a delaware limited liability,kalologie 360 spa
 kampgrounds america,koa
 kampgrounds america koa,koa
 katsu bar and noodle (katsu bar),katsu bar noodle
 keen learners montessori,keen learners
+keepsake companions,keepsake
+keepsake keepsake companions keepsake choices,keepsake
 kei windows,kei window cleaning
 keke's breakfast café,kekes breakfast cafe
 keller williams realtors,keller williams
+keller williams realty inc market center,keller williams
 keller williams realty market center,keller williams
 keller williams realty market centers,keller williams
 keller williams realty regional representative,keller williams
@@ -1503,9 +1749,13 @@ kennedy transmission,kennedy transmission brake auto service
 kennedys all american barber club,kennedys barber club
 key west innshotelsresorts,key west inns hotels resorts
 keylingo,keylingo franco
+keylingo translations,keylingo franco
 keystone,keystone insurers
+keystone insurers group,keystone insurers
 keystone insurers services group,keystone insurers
+kfc corporation,kfc
 kfc express,kfc
+kfc kentucky fried chicken,kfc
 kfc taco bell multi brand restaurant,kfc
 kickhouse fitness,kickhouse
 kidcreate,kidcreate studio
@@ -1513,6 +1763,11 @@ kiddie academy child care learning center,kiddie academy
 kiddie academy child care learning centers,kiddie academy
 kids r kids learning academies,kids r kids
 kidzart club scientific,kidzart
+kidzart club scientific co branded kidzart club scientific,kidzart
+kidzart co branded with club scientific,kidzart
+kidzart teach club scientific teach co branded,kidzart
+kimpton,kimpton hotels restaurants
+kimpton hotels,kimpton hotels restaurants
 king jane cbd,king jane
 kitchen tune,kitchen tune up
 kitchen tune-up,kitchen tune up
@@ -1520,6 +1775,8 @@ kitchentune up,kitchen tune up
 knights,knights inn
 knights inn knights inn suites,knights inn
 knockouts area representative program,knockouts
+knockouts haircuts for men,knockouts
+koa kampgrounds america,koa
 koa kampgrounds of america,koa
 koiache factory,kolache factory
 krave kobe burger,krave kobe burger grill
@@ -1530,11 +1787,15 @@ kumon math reading centers,kumon
 kumon reading center others,kumon
 kung fu tea shop,kung fu tea
 kure store,kure
+kure store kore select store,kure
 kwench juice café,kwench juice cafe
 kwik kopy business center,kwik kopy
 kwik kopy business centers,kwik kopy
+kwik kopy printing kwik kopy business center franklins printing center,kwik kopy
+kwik kopy printing kwik kopy business center franklins printing center ink well printing center,kwik kopy
 l a insurance agency,la insurance
 l ce ny,i ce ny
+l l drive inn l l hawaiian barbecue l l hawaiian grill l l hawaiian mixplate,l l hawaiian barbecue
 la bikini,la bikini studios
 la bottega italian gourmet restaurant,la bottega italian gourmet
 la boulangerie,la boulangerie bakery cafe
@@ -1542,7 +1803,9 @@ la boulangerie bakery cafes,la boulangerie bakery cafe
 la boulangerie bakery cafés,la boulangerie bakery cafe
 la madeleine country french cafe,la madeleine
 la madeleine french bakery cafe,la madeleine
+la quinta,la quinta wyndham
 la quinta inn,la quinta wyndham
+la quinta inn la quinta inn suites,la quinta wyndham
 la quinta inn suites,la quinta wyndham
 la vida massage,lavida massage
 la weight loss,l a weight loss centers
@@ -1553,12 +1816,15 @@ lapels dry cleaning,lapels
 larosas,larosas pizzeria
 lash spas,lash
 launch trampoline park,launch park
+lawn army yellow van handyman,lawn army
 lawn doctor complete 31 document,lawn doctor
 lawndoctor,lawn doctor
-le créme,le creme
 le crème,le creme
+le créme,le creme
+le meridien hotels resorts,le meridien
 le méridien,le meridien
 le village marché,le village
+leadership development group,leadership
 leadership management,lmi
 leadership management institute,NA
 leading edge design,prosource wholesale
@@ -1575,7 +1841,6 @@ learning express toys,learning express toys gifts
 learning rx,learningrx
 learningexpress,learning express toys gifts
 learningrx training center,learningrx
-lêberry bakery donut,leberry bakery donut
 ledgers unit,ledgers
 lee sandwiches,lees sandwiches
 lees famous recipe,lees famous recipe chicken
@@ -1589,6 +1854,7 @@ lennys sub shop,lennys grill subs
 lennys sub shops,lennys grill subs
 level up automation,level up your home
 level up automation level up your home,level up your home
+lexington inn lexington hotel,lexington
 liberty fitness for women,liberty fitness
 liberty tax,liberty tax service
 libertytax,liberty tax service
@@ -1600,11 +1866,13 @@ lifexist center,lifexist
 lifexist wellness center,lifexist
 lighthouse landscape lighting,lighthouse
 lighthouse outdoor living,lighthouse
+lighthouse outdoor living lighthouse landscape lighting,lighthouse
 lightning rain gutters,lightning raingutters
 lil genius kid,genius kids
 lil genius kid genius kids genius kids club,genius kids
 line,line x
 line service,linc service
+line system line service,line x
 line x protective coatings,line x
 link business,link staffing
 link staffing services,link staffing
@@ -1613,6 +1881,7 @@ liquid capital pdo franchise,liquid capital
 liquivida,liquivida lounge
 lite for life,lite choice
 little caesar,little caesars
+little caesars carryout delivery,little caesars
 little greek,little greek fresh grill
 little greek fresh grill restaurant,little greek fresh grill
 little gym japan,little gym
@@ -1625,9 +1894,15 @@ little sunshine playhouse,little sunshines playhouse preschool
 little sunshines,little sunshines playhouse preschool
 littlekabuki restaurant,littlekabuki
 livhome senior care,livhome
+livsmart,livsmart studios hilton
+livsmart studios,livsmart studios hilton
+lmi franchise,lmi
 locah healthy convenience,locali healthy convenience
 local store,learning express toys gifts
 locos grill pub,locos deli pub
+lodie s shaved ice shack,summer snow
+lodies shaved ice shack,summer snow
+lollicup franchise,lollicup
 lollicup store,lollicup
 lolos chicken waffles,lo los chicken waffles
 long island bagel café,long island bagel cafe
@@ -1641,7 +1916,10 @@ louisiana madeleine,la madeleine
 lubepros service center,lube pros
 lunchbox,radiant waxing
 lunchboxwax,radiant waxing
+luxury limo group,luxury limo
+lxr hotels,lxr hotels resorts
 lyons restores evans garment restoration,evans garment restoration
+lêberry bakery donut,leberry bakery donut
 m c spa,mc spa
 m g m liquor warehouse,mgm wine spirits
 m g m wine spirits,mgm wine spirits
@@ -1650,14 +1928,18 @@ maaco collision repair auto painting,maaco
 macchiato,macchiato cafe
 macchiato cafes,macchiato cafe
 mactools,mac tools
+macu master,macu
 made in shade,made in the shade blinds more
 maggianos,maggianos little italy
 magic brow salon,magic brow
 magnuson grand,magnuson
+magnuson grand magnuson hotels,magnuson
 magnuson grand or magnuson hotels,magnuson
 magnuson hotels,magnuson
 mahana poke,mahana fresh
 mai,mai sushi bar
+mai cuisine,mai sushi bar
+mai franchising,mai sushi bar
 mai sushi,mai sushi bar
 maid brigade usa minimaid canada,maid brigade
 maid pro,maidpro
@@ -1665,24 +1947,32 @@ maid simple,maid simple house cleaning
 maids home service,marigold pest services
 maids international,maids
 maiiroom home care,griswold home care
+mainstay,mainstay suites extended stay choice hotels
 mainstay suites,mainstay suites extended stay choice hotels
 mainstream boulique,mainstream boutique
 mainstream boutiquesm,mainstream boutique
 mama de luca's,mama delucas
 mama delucca's,mama delucas
 mama fus,mama fus asian house
+mamouns falafel,mamouns
 management recruit,mrinetwork
 management recruiters,mrinetwork
 manchu wok shopping mall non traditional program,manchu wok
+manduu ems lifestyle workout,manduu
 mango mango dessert,mang mang dessert
 mango six,mango
 marco’s pizza,marcos pizza
 margaritas restaurant,NA
+marilyn monroe glamour,marilyn monroe spas
 marilyn monroe nail lounge,marilyn monroe spas
+marilyn monroe nail lounge marilyn monroe glamour room,marilyn monroe spas
+marilyn monroe spas marilyn monroe nail lounge marilyn monroe glamour room,marilyn monroe spas
 marriott execustay,execustay
 marriott hotel,marriott hotels
+marriott hotels marriott resorts marriott suites hotels jw marriott hotels marriott marquis hotels marriott hotel conference centers,marriott hotels
 marriott hotels resort,marriott hotels
 marriott hotels resorts,marriott hotels
+marriott jw marriott,marriott hotels
 mars,mars miracle appearance reconditioning mobil
 marshall face face,marshall face2face
 martinizing delivers,martinizing dry cleaning
@@ -1696,6 +1986,7 @@ mastertech mold,mastertech environmental
 matchbox,matchbox restaurant
 matco,matco tools
 matco distributorship,matco tools
+matco tools distributorship,matco tools
 matco tools rent tools,matco tools
 mateo tools,matco tools
 mathnasium,mathnasium learning centers
@@ -1705,6 +1996,7 @@ maui wowi hawaiian coffees smoothies,maui wowi
 maui wowl marketing,maui wowi
 max muscle sports nutrition,max muscle
 max restaurant,max challenge
+maxim group,maxim
 maximizedliving,maxliving
 maximo auto insurance,maximo
 maxmuscle,max muscle
@@ -1713,10 +2005,16 @@ maxs restaurant cuisine philippines,maxs manila
 maxs restaurant cuisine the philippines,maxs manila
 mazzios restaurants,mazzios italian eatery
 mcalister deli,mcalisters deli
-mcdonald’s,mcdonalds
 mcdonalds,mcdonalds
+mcdonald’s,mcdonalds
 mcfadden restaurant saloon,mcfaddens restaurant saloon
 me n eds pizzeria,me n eds
+me n eds pizzeria me n eds on tap,me n eds
+me n eds pizzerias,me n eds
+me n eds pizzerias me n eds pizza pastarias me n eds grills angelo vitos pizzerias blast 825 pizza,me n eds
+me n eds pizzerias me n eds pizza pastarias me n eds grills angelo vitos pizzerias blast 825 pizza blast pizza,me n eds
+me n eds pizzerias me n eds pizza pastarias me n eds grills angelo vitos pizzerias me n eds slices pizza bars,me n eds
+me n eds pizzerias me n eds pizza pastarias me n eds grills angelo vitos pizzerias me n eds slices pizza bars blast 825,me n eds
 meadows original frozen custard stand,meadows original frozen custard
 meals of hope logistics,NA
 meals of hope logistics inc,NA
@@ -1730,9 +2028,10 @@ medifast weight control center,medifast weight control centers
 meinecke car care centers,meineke car care center
 melton,melty
 melty way,melty
-mfm,my favorite muffin
 menchie,menchies
 menchie’s,menchies
+meridien,le meridien
+merle norman cosmetic studio,merle norman
 merle norman cosmetics studio,merle norman
 merlin 200 000 mile shops,merlin complete auto care
 merlin 200 000 miles shop,merlin complete auto care
@@ -1741,6 +2040,7 @@ merlin miles shop,merlin complete auto care
 metal supermarkets america,metal supermarkets
 metal supermarkets at 2 13,metal supermarkets
 metrofiex gym,metroflex gym
+mfm,my favorite muffin
 mho,mho hotels
 mi box mobile storage moving,mi box
 miami subs grill,miami grill
@@ -1754,7 +2054,9 @@ microtel inn suites,microtel inn suites wyndham
 microtel inns suites,microtel inn suites wyndham
 microtel wyndham,microtel inn suites wyndham
 midas shop,midas
+midas speedee,midas speedee oil change auto service
 midas speedee shop,midas
+midici neapolitan pizza,midici
 mighty,mighty auto parts
 mighty distributing,mighty auto parts
 mighty distributing system america,mighty auto parts
@@ -1779,6 +2081,7 @@ mio sushi mio ro,mio sushi
 miracle method of the northwest,miracle method
 miracle method surface refinishing,miracle method
 miracle method surface restoration,miracle method
+miracle method us surface refinishing,miracle method
 miracle-ear,miracle ear
 mircale ear,miracle ear
 miss teen,miss teen usa pageant
@@ -1793,12 +2096,13 @@ mobil,NA
 mobility,mobility city
 moes original bar b q,moes original bar b que
 moes original bbq,moes original bar b que
-möge tee,moge tee
 moneymailerusa inc.,money mailer
 monkey joes parties play,monkey joes
 montessori kids universe mku,montessori kids universe
 montessori pre school,keen learners
+mood media,mood
 mooyah burgers fries shakes,mooyah
+more space place closet storage concepts,more space place
 morrison plus property inspection,morrison plus property inspections
 mosquito hunters humbug holiday lighting,mosquito hunters
 mosquito squad copy,mosquito squad
@@ -1824,15 +2128,19 @@ mr rooter,mr rooter plumbing
 mr sandless dr decknfence,mr sandless
 mr sub,mr submarine
 mr transmission milex complete auto care,atlas transmission
+mr transmission milex complete auto care co branded,atlas transmission
 mr transmission multistate transmissions,mr transmission
 mr transmission multistate transmissions milex complete auto care,mr transmission
 mr transmission transmission,mr transmission
 mr. pickle’s sandwich shop,mr pickles sandwich shop
 mr. rooter,mr rooter plumbing
+mrcool distribution center,mrcool
 mri network,mrinetwork
 mrinetwork office directory,mrinetwork
 mrs fields cookie,mrs fields
 mrs fields cookie store,mrs fields
+mrs fields cookie store tcby store co branded store,mrs fields
+mrs fields famous brands,mrs fields
 mto cleaning services,mtoclean
 murphy business,murphy business sales
 murphy regional developer business,murphy business sales
@@ -1851,7 +2159,11 @@ myfit 18,myfit18
 myfitl8,myfit18
 mytaxfiler globalcfoservice,mytaxfiler
 myungrang korean hot dog,myungrang korean hot dog shops
+möge tee,moge tee
+n hance business,n hance
+n hance revolutionary wood renewal,n hance
 n hance wood refinishing,n hance
+n hance wood renewal,n hance
 n yo frozen yogurt,nuyo frozen yogurt
 n zone sports,nzone sports
 n2 publishing,stroll
@@ -1871,17 +2183,16 @@ natures table café,natures table
 natures way cafe,natures table
 naugles,naugles tacos burgers
 naya dessert café,naya dessert cafe
+neehees restaurant,neehees
 neighborhood barre studio,neighborhood barre
 nekt royal juice bar,nekter juice bar
-nékt…ôr juice bar,nekter juice bar
 nekt0r juice bar,nekter juice bar
-néktər juice bar,nekter juice bar
 nektor juice bar,nekter juice bar
 nerds to go,nerdstogo
 nerdstogo office,nerdstogo
+nestle toll house café chip,nestle toll house cafe chip
 nestlé toll house cafe by chip,nestle toll house cafe chip
 nestlé toll house café by chip,nestle toll house cafe chip
-nestle toll house café chip,nestle toll house cafe chip
 new horizons group,new horizons
 nexgenesis healthcare,nexgenesis
 nextage,nextage realty
@@ -1895,26 +2206,35 @@ noble roman pizza tuscan italian style subs,noble romans
 noble romans craft pizza pub,noble romans
 noble romans inc - s,noble romans
 noble romans pizza,noble romans
+noble romans pizza tuscanos italian style subs,noble romans
 novus,novus glass
 novus auto glass,novus glass
+novus glass repair replacement,novus glass
+novus novus glass,novus glass
 novus retail location,novus glass
 novusglass,novus glass
 npi,national property inspections
 nu lkcow,nu flow
 nurse next door home care services,nurse next door
+nurse next door home healthcare,nurse next door
 nutnshop,nutrishop
 nutri system weight loss,nutri weight loss
 nutrishop store,nutrishop
 nutritious,b nutritious
+nylo hotels,nylo
 nylo hotels xp nylo,xp nylo
 nys collection,nys collection eyewear
 nzone,nzone sports
 nzone sports america,nzone sports
+néktər juice bar,nekter juice bar
+nékt…ôr juice bar,nekter juice bar
 oakwood waterwalk,waterwalk
+oakwood waterwalk property,waterwalk
 office pride commercial cleaning,office pride
 office pride commercial cleaning services,office pride
 oggi,oggis
 oggis pizza brewing,oggis
+ohana bros island style shave ice fries chips popcorn,ohana bros
 oilstop,oilstop drive thru oil change
 oksana enrichment,oksana enrichment programs
 old chicago restaurants,old chicago pizza taproom
@@ -1923,6 +2243,7 @@ old new york deli restaurants,old new york deli bakery
 omex office maintenance experts,omex
 on border mexican grill cantina,on the border
 on go spa,on the go spa on the go zen
+on the border mexican grill cantina,on the border
 on the go spa,on the go spa on the go zen
 on the go zen,on the go spa on the go zen
 one glow sauna studios,glow sauna studios
@@ -1947,9 +2268,12 @@ oreck clean home center,oreck
 original soup man u 38 complete 06,original soup man
 original soupman,original soup man
 orion,orion food
+orion brand hot stuff pizza,hot stuff pizza
 orozco auto service,orozcos auto service
 orozco’s auto service,orozcos auto service
+orthonow orthopedic urgent care,orthonow
 osi old skool iron iron rose,osi
+osi training facility,osi
 our town,our town america
 our town logo,our town america
 outback steakbouse,outback steakhouse
@@ -1977,6 +2301,7 @@ pack mail,pak mail
 packagehub business centers,packagehub business center
 packouts,1 800 packouts
 padadak,padadak korean chicken
+padadak restaurants,padadak korean chicken
 padgett,padgett business services
 pafrol services,patrol services
 paik noodle,paiks noodle
@@ -1991,6 +2316,7 @@ pakmail centers america,pak mail
 palm beach tan desert sun tanning salons,palm beach tan
 panchero,pancheros mexican grill
 pancheros,pancheros mexican grill
+pancheros restaurant,pancheros mexican grill
 panera bread bakery cafe,panera bread
 panini kabob grill,panini kabob grill healthier mediterranean food
 pans baguette,paris baguette
@@ -1998,8 +2324,8 @@ papa john\'s,papa johns
 papa murphy,papa murphys take n bake pizza
 papa saverios,papa saverios pizzeria
 paradis cafe,paradis
-paradis café,paradis
 paradis cafes,paradis
+paradis café,paradis
 paradise bakery & café,paradise bakery
 paramount tax,paramount tax accounting
 paris a baguette,paris baguette
@@ -2010,11 +2336,11 @@ parker-anderson ennchment,parker anderson enrichment
 party giant,NA
 passport health travel business,passport health
 pastalini restaurant,pastalini
+patsys italian restaurant,patsys italian restaurant
+patsys pizzeria,patsys pizzeria
 patsy country kitchen,patsys country kitchen
 patsy pizzeria,patsys pizzeria
 patsy’s pizzeria,patsys pizzeria
-patsys italian restaurant,patsys italian restaurant
-patsys pizzeria,patsys pizzeria
 patxis restaurants,patxis pizza
 paul david emergency services,paul davis emergency services
 paulie gee,paulie gees
@@ -2025,6 +2351,7 @@ paymore store,paymore
 pddvos,paavos pizza
 peak centre,peak centre for human performance
 peak franchising,max muscle
+pearle vision eyecare center,pearle vision
 pedro tacos,pedros tacos
 pedros mexican restaurante,pedros tacos
 pelican snoballs,pelicans snoballs
@@ -2047,19 +2374,23 @@ persona neapolitan pizzeria,persona wood fired pizzeria
 persona pizzeria,persona wood fired pizzeria
 pestmaster,pestmaster services
 pestmaster network,pestmaster services
+pet butler lawn army yellow van handyman,pet butler
 petdoc2u,petdoc2u mobile veterinary clinic
-phá ÿ hã aâ,pho hoa
 phase family learning center,phase family center
 philly dawgz chicago style,philly dawgz
-philly’s best authentic cheesesteak & hoagie shop,phillys best authentic cheesesteak hoagie shop
 phillys best authentic cheesesteak hoagieshop,phillys best authentic cheesesteak hoagie shop
+philly’s best authentic cheesesteak & hoagie shop,phillys best authentic cheesesteak hoagie shop
+pho hoa pho hoa,pho hoa
+phá ÿ hã aâ,pho hoa
 phở hòa,pho hoa
+pibcoa injury healing centers america,pibcoa
 pie five,pie five pizza
 pier pizza,NA
 pillar to post home inspectors,pillar to post
 pillar to post inspection services,pillar to post
 pinkberry shops,pinkberry
 pinkberry ventures,pinkberry
+pip center postal instant press,pip center
 pip marketing signs print,pip center
 pip printing,pip center
 pip printing document services,pip center
@@ -2097,15 +2428,15 @@ pnmp blow,primp blow a blow dry bar
 pntikm,pritikin certified icr
 pok rainbow,poke rainbow
 poke bar,poke bar dice mix
+poke bum,poke burri
+poke mahi,pokemahi
+pokworks,pokeworks
 poké bar,poke bar dice mix
 poké bar dice mix,poke bar dice mix
 poké bar restaurant,poke bar dice mix
-poke bum,poke burri
 poké house,poke house
-poke mahi,pokemahi
 poké rainbow,poke rainbow
 pokéworks,pokeworks
-pokworks,pokeworks
 polestar pilates studio,polestar pilates
 polestar studio,polestar pilates
 polio campero,pollo campero
@@ -2129,6 +2460,7 @@ postnet postal business services,postnet
 postnet v4f @xce74d,postnet
 postnet v4f atxce74d,postnet
 potato comer,potato corner
+potato comer restaurants,potato corner
 potato corner restaurants,potato corner
 potbelly sandwich works,potbelly sandwich shop
 potbelly sandwich workshop,potbelly sandwich shop
@@ -2149,16 +2481,22 @@ priceless rent a car,priceless car truck rental
 primp blow,primp blow a blow dry bar
 pritikin,pritikin certified icr
 pritikin certified,pritikin certified icr
+pritikin intensive cardiac rehab program icr,pritikin certified icr
 pritikin program,pritikin certified icr
 pritikin-certified icr program,pritikin certified icr
 pro cuts classic,pro cuts
 pro cuts sport,pro cuts sports
 pro golf,pro golf discount
 pro image,pro image sports
+pro image franchise lc,pro image sports
 pro lift doors,pro golf discount
 pro one,pro one janitorial
+professionals realty group,professionals realty
+proforma franchise global graphics network ggn,proforma
 proforma global graphics network ggn,proforma
+proforma proforma for printers,proforma
 proimage,pro image sports
+project walk spinal cord injury recovery center,project walk
 promartialarts,grandmaster samanes pro martial arts karate
 pronto insurance,pronto
 prontoroni,prontoronis pronto pizza
@@ -2172,6 +2510,7 @@ prose salon,prose boutique
 prosource,prosource wholesale
 prosource wholesale floorcovenngs,prosource wholesale
 prosource wholesale floorcoverings,prosource wholesale
+prosource wholesale floorcoverings showroom,prosource wholesale
 prosource wholesale showroom,prosource wholesale
 protect painetrs,protect painters
 protein house,proteinhouse
@@ -2188,14 +2527,22 @@ qdoba mexican grill,qdoba mexican eats
 qdoba restaurant,qdoba mexican eats
 quaker steak lube restaurant,quaker steak lube
 quality,quality choice hotels
+quality brand quality inn quality inn suites quality suites quality hotel quality resort,quality choice hotels
+quality franchise program,quality choice hotels
 quality inn,quality choice hotels
+quality inn family brands quality inn quality inn suites quality suites quality hotel quality resort,quality choice hotels
+quality inn quality inn brand family,quality choice hotels
 quality inn quality inn suites quality suites quality hotel or quality resort,quality choice hotels
+quality inn quality inn suites quality suites quality hotel quality resort,quality choice hotels
+quality quality inn quality inn suites quality suites quality hotel quality resort,quality choice hotels
 quality tune up shop,quality tune up shops
 quality tune-up shops (qts),quality tune up shops
 queen bee salons,queen bee salon spa
+quiznos quiznos sub,quiznos
 quiznos restaurant,quiznos
 quiznos sub,quiznos
 r b store,r b
+r k cafe,rice king
 r taco,rusty taco
 r win dow cl eaning,kei window cleaning
 r3vive,revive
@@ -2203,6 +2550,9 @@ rachels kitchen little rachels kitchen,rachels kitchen
 radisson hotels resorts worldwide,radisson
 rainbow carpet dyeing cleaning,rainbow international restoration
 rainbow restoration cleaning,rainbow international restoration
+rainbow station,leafspring school
+rallys restaurant,rallys
+ramada,ramada wyndham
 ramada,ramada wyndham
 ramada ramada plaza hotel,ramada wyndham
 rapid refill ink,rapid refill
@@ -2210,6 +2560,7 @@ rapidrecovery,rapid recovery
 raw fitness center,raw fitness
 re max integra,re max
 re max north central,re max
+re max pacific northwest region,re max
 re realty experts,realty experts
 reading readiness,reading readiness centers
 real deals on home décor,real deals on home decor
@@ -2219,6 +2570,7 @@ real property management parial,real property management
 realliving,real living real estate
 realty exec,realty executives
 realty executives svcs,realty executives
+realty one group,realty one
 realty world broker network,realty world
 realty world northern california,realty world
 ream franchise group llc,NA
@@ -2228,6 +2580,7 @@ red box +,redbox
 red box+,redbox
 red brick pizza cafe,red brick pizza
 red lion hotel red lion inn suites,hotel rl red lion
+red lion inn suites,red lion
 red mango cafe juice bar,red mango
 red mango frozen yogurt smoothies,red mango
 red mango yogurt cafe juice bar,red mango
@@ -2237,21 +2590,33 @@ red roof inns,red roof inn
 redbox dumpsters,redbox
 redbrick pizza,red brick pizza
 redline recreational,redline
+redroof,red roof inn
+redroof inn,red roof inn
 redstraw outlets,redstraw
 redwood healthcare,redwood healthcare staffing
+regal maid service royal maid service,regal maid service
 regency group,regency
+regency office products,regency
 registry collection,registry collection hotels
 registry collection hotel,registry collection hotels
+regus office,regus
 reis & irvy’s,reis irvys
 reis irvy,reis irvys
 relax back,relax the back
+reliable facility group,reliable facility
+relive health,relive
+relive health ar,relive
+relive health unit,relive
 remax,re max
 remedy,remedy intelligent staffing
 renaissance hotel,renaissance hotels
+renaissance hotel renaissance resort renaissance hotel conference center,renaissance hotels
 renaissance hotels resorts,renaissance hotels
 renew clean,renew crew
+renew medic,renew
 renovation realty,renovation sells
 rent n roll,rnr tire express
+rent n roll rnr custom wheels tires,rnr tire express
 rent n roll rnr custom wheels tires rnr tire express,rnr tire express
 rent wreck,rent a wreck
 rent-a-wreck system international,rent a wreck
@@ -2273,9 +2638,9 @@ retro fitness,retrofitness
 reup living,reup
 revel jun kombucha bars,revel jun kombucha bar
 reverb,reverb hard rock
+rhea lanas franchise,rhea lanas
 rhea lana’s,rhea lanas
 "rhea lana’s franchise systems, inc.",rhea lanas
-rhea lanas franchise,rhea lanas
 rice king r k cafe,rice king
 rice kmg,rice king
 right place for seniors,a right place for seniors
@@ -2284,7 +2649,10 @@ rise n roll bakery deli,risen roll bakery deli
 rising roll,rising roll gourmet cafe
 ritas frozen ice,ritas ice custard happiness
 ritas italian ice,ritas ice custard happiness
+ritz carlton,ritz carlton residences
+ritzcarlton,ritz carlton residences
 river street sweets – savannah’s candy kitchen,river street sweets savannahs candy kitchen
+rk cafe,rice king
 rlls,searchpath
 rnr custom wheels tire express,rnr tire express
 rnr custom wheels tires,rnr tire express
@@ -2302,8 +2670,8 @@ rodeway inn rodeway inn suites,rodeway inn
 roly poly sandwich shops,roly poly sandwiches
 roni deutch tax,roni deutch tax center
 roosters,roosters mens grooming center
-roosters men’s grooming center,roosters mens grooming center
 roosters mens grooming centers,roosters mens grooming center
+roosters men’s grooming center,roosters mens grooming center
 rooterman,rooter man
 rosati pizza,rosatis pizza
 rosatis,rosatis pizza
@@ -2320,14 +2688,26 @@ rsvp publications,rsvp
 ruby diner,rubys diner
 rubys dinette,rubys diner
 rush studio,rush cycle
+s t o p,drymedic restoration services
 saemaeul restaurant,saemaeul
+saemaeul shikdang noodle j 1,saemaeul
 safan kid,safari kid
 safesplash,safesplash swim school
+safesplash brands streamline brands,safesplash swim school
 safesplash swimlabs,safesplash swim school
 safesplash swimlabs swimtastic,safesplash swim school
 saffron,saffron mediterranean kitchen
 salad works,saladworks
+salon plaza,my salon suite
+salon professional academy the academy for salon mastery elevate salon institute,salon professional academy
+salon professional academy tspa elevate salon institute esi brands spec,salon professional academy
+salon professional academy tspa elevate salon institute esi spa pro academy spa,salon professional academy
+salon professional academy tspa elevate salon institute esi spa pro academy spa brands offered spec,salon professional academy
+salon professional academy tspa or elevate salon institute esi,salon professional academy
+salon professional academy tspa the academy for salon mastery asm elevate salon institute esi,salon professional academy
+salon professional academy tspa the academy for salon mastery asm elevate salon institute esp,salon professional academy
 salon professional education,salon professional academy
+salon professional education company llc doing business as spec,salon professional academy
 salsantas fresh cantina,salsaritas fresh mexican grill
 salsaritas fresh cantina,salsaritas fresh mexican grill
 sam louies,sam louies new york pizzeria
@@ -2353,8 +2733,15 @@ scooter coffee,scooters coffee
 scooters,scooters coffee
 scooters coffee yogurt,scooters coffee
 scooters coffeehouse,scooters coffee
+scottish inns scottish inns suites red carpet inn red carpet suites red carpet inn suites master hosts inns master hosts resort passport inn passport inn suites downtowner inns downtowner inns suites,scottish inns
 scottish inns scottish suites red carpet inn red carpet suites master hosts inns passport inn downtowner inns,scottish inns
+scottish inns scottish suites scottish inns suites red carpet inn red carpet inn suites red carpet inn suites master hosts inns master hosts resort passport inn passport inn suites downtowner inns downtowner inns suites,scottish inns
+scottish inns scottish suites scottish inns suites red carpet inn red carpet suites red carpet inn suites master hosts inns master hosts resort passport inn passport inn suites downtowner inns downtowner inns suites,scottish inns
+scottish inns scottish suites scottish inns suites scottish lodge scottish inns lodge red carpet inn red carpet inn suites master hosts inns master hosts resort passport inn passport inn suites downtowner inns downtowner inns suites,scottish inns
+scottish inns scottish suites scottish inns suites scottish lodge scottish inns lodge red carpet inn red carpet inn suites red carpet inn suites master hosts inns master hosts resort passport inn passport inn suites downtowner inns downtowner inns suites,scottish inns
+scottish inns scottish suites scottish inns suites scottish lodge scottish inns lodge red carpet inn red carpet inn suites red carpet suites master hosts inns master hosts resort passport inn passport inn suites downtowner inns downtowner inns suites,scottish inns
 scottish inns scottish suites scottish inns suites scottish lodge scottish inns lodge red carpet inn red carpet suites red carpet inn suites master hosts inns master hosts resort passport inn passport inn suites downtowner inns downtowner inns suites,scottish inns
+scottish inns scottish suites scottish lodge scottish inn suites red carpet inn red carpet inn suites downtowner inns downtowner inns suites passport inn passport inn suites master hosts inns master hosts resort inns suites,scottish inns
 scotts lawn,scotts lawnservice
 scotts lawn service,scotts lawnservice
 scottslawn,scotts lawnservice
@@ -2377,15 +2764,21 @@ second family,2nd family
 second shift sewer plumbing,2nd shift sewer plumbing
 second time sports,2nd time sports
 sellstate realty,sellstate
+send me a pro franchise send me a trainer,send me a pro
 senior choice,seniors choice
 serotonin centers,serotonin
 serv pro,servpro
 service team professionals,drymedic restoration services
+service team professionals property restoration specialists,drymedic restoration services
 servicemaster clean,servicemaster
 servicemaster clean servicemaster restore,servicemaster
+servicemaster clean servicemaster restore servicemaster recovery management,servicemaster
 servicemaster home services plumbing,servicemaster plumbing
 servicemaster plumbing area representative,servicemaster plumbing
+servicemaster residential commercial services,servicemaster
+servicemaster residential commercial services limited partnership,servicemaster
 servicemaster restore,servicemaster
+servpro distributor,servpro
 servpro industries,servpro
 settle inn,settle inn extended stay
 settle inn hotel,settle inn extended stay
@@ -2398,6 +2791,9 @@ shelf g,shelfgenie
 shelfg,shelfgenie
 sheraton hotel,sheraton
 sheraton hotels,sheraton
+sheraton hotels resorts,sheraton
+shilo inns suites hotels,shilo inns
+shine window care,shine
 shine window care holiday lighting,shine
 shokeaway,shakeaway
 shoneys restaurants,shoneys inn
@@ -2405,14 +2801,19 @@ shred,shred415
 shuang jiang cream in tea,shuang jiang cream in tea 1986
 shubh beauty,shubh beauty salon
 shulas steak house,shulas
+shulas steak houses,shulas
+shulas steak houses brands include shulas steak house shulas 2 steak sports shulas 347 grill shulas on the beach steakbar 347 shulas,shulas
+shulas steak houses shulas steak house shulas 2 steak sports shulas 347 grill shulas on the beach,shulas
 siempre tax,siempretax
 sign a rama,signarama
 sign a ramasignarama,signarama
 signal 88,signal
+signal 88 franchise group,signal
 signal 88 group,signal
 signal 88 security,signal
 signal graphics,signal graphics printing
 signal graphics business center,signal graphics printing
+signal health group,signal health
 signal security,signal
 signal88,signal
 signature branded hotel,signature
@@ -2430,6 +2831,7 @@ sir speedy printing centers,sir speedy
 sir speedy printing marketing services,sir speedy
 sit means sit dog training,sit means sit
 sit still kids,sit still kids salon
+sitters etc,sei healthcare services
 skin type solutions stores,skin type solutions
 skinny pizza,skinnypizza
 skinny wimp,skinny wimp moving
@@ -2439,7 +2841,9 @@ skyhawks sports supertots sports academy,skyhawks
 slaters 50 50,slaters 50 50 burgers design
 sleep,sleep first
 sleep inn,sleep inn choice hotels
+sleep inn sleep inn suites,sleep inn choice hotels
 sloan,sloans
+sloans ice cream,sloans
 sls franchise,scotts lawnservice
 slumber land,slumberland
 slumberland mattress plus,slumberland
@@ -2452,7 +2856,9 @@ smootmic cofpcc shaved ice,its boba time
 snaggle foot dog walks pet care,snaggle foot
 snap on tools,snap on
 snap-on,snap on
+snelling hirequest direct,snelling
 snelling staffing services,snelling
+snelling staffing viking staffing link staffing,snelling
 snow fox,snowfruit
 snow fruit,snowfruit
 snowfin,snowfruit
@@ -2473,28 +2879,45 @@ sorbenots coffee shops,sorbenots coffee
 sotheb,sothebys international realty
 sound lion store,sound lion
 south philly,south philly steaks fries
+south philly steaks fries south philly cheesesteaks fries,south philly steaks fries
 south phillysteaks fries,south philly steaks fries
 southern maid,southern maid donuts
 southern painting,NA
 spa 810,medspa810
 spa810,medspa810
+sparkle wash international cleaning service,sparkle wash
 sparklewash,sparkle wash
 spavia day spa,spavia
 spec,salon professional academy
+spec brands the salon professional academy academy for salon mastery elevate salon institute brands under spec,academy for salon mastery
+spec brands the salon professional academy tspa elevate salon institute esi spa pro academy spa,salon professional academy
+spec salon professional education,salon professional academy
+spec salon professional education company llc d b a spec,salon professional academy
+spec salon professional education company llc dba spec the salon professional academy tspa the academy for salon mastery asm elevate salon institute esi,salon professional academy
+spec salon professional education company llc doing business as spec,salon professional academy
+spec salon professional education company llc doing business as spec brands include the salon professional academy tspa the academy for salon mastery asm elevate salon institute esi,salon professional academy
+spec salon professional education company llc doing business as spec brands the salon professional academy tspa the academy for salon mastery asm elevate salon institute esi,salon professional academy
+spec salon professional education company llc doing business as spec the salon professional academy tspa elevate salon institute esi spa pro academy spa,salon professional academy
+spec salon professional education company llc the salon professional academy tspa elevate salon institute esi spa pro academy spa,salon professional academy
 specific chiropractic center,specific chiropractic centers
 speed pro,speedpro
 speedee oil change & tune up auto service,speedee oil change auto service
 speedee oil change auto service center,speedee oil change auto service
 speedee oil change tune up,speedee oil change auto service
 speedpro imaging,speedpro
+speedpro imagingstudio,speedpro
 speedpro imanging,speedpro
 speedpro studio,speedpro
 sperry commercial global affiliates (sperrycga),sperry commercial global affiliates
 sperry van ness,svn
+sperry van ness svn,svn
 spherion,spherion staffing recruiting
 spice merchants spice tea merchants,spice merchants
 spidersmart learning center,spidersmart learning
+spin doctor laundromat,spin
+spin galactic,spin
 spitz home doner keba,spitz
+spitz home the doner kebab,spitz
 spitz restaurants,spitz
 splash dash groomerie boutique,splash dash
 sport clips haircuts,sport clips
@@ -2502,8 +2925,10 @@ sportclips,sport clips
 sports clips,sport clips
 spring green lawn care,spring green
 springgreen,spring green
+springhill,springhill suites marriott
 springhill suites,springhill suites marriott
 sprinkles cupcakes,sprinkles
+sprinkles cupcakes bakery,sprinkles
 squeeze shop,NA
 sr. ozzy’s tacos y mariscos,sr ozzys tacos y mariscos
 stagecoach theatre arts schools,stagecoach
@@ -2512,10 +2937,13 @@ stanley steemer carpet cleaner,stanley steemer
 starting strength gym,starting strength
 stay express,stay express inn
 stayapt,stayapt suites
+staybridge,staybridge suites
 staybridge suites holiday inn,staybridge suites
 steak escape,steak escape sandwich grill
+steak escape steak escape sandwich grill steak escape grille steak escape express,steak escape sandwich grill
 steak n shake,steak n shake biglari
 steamatic restoration clea,steamatic
+steamatic restoration cleaning,steamatic
 steri glean,steri clean
 sterling optical center,sterling optical
 stevi pizza,stevi bs pizza
@@ -2523,6 +2951,9 @@ stick house,stickhouse
 stickhouse gelato,stickhouse
 stickhouse shops,stickhouse
 stop,drymedic restoration services
+stop disaster restoration,drymedic restoration services
+stop property restoration specialists,drymedic restoration services
+stop restoration,drymedic restoration services
 storm guard restoration,storm guard
 storm guard roofing construction,storm guard
 straight source,straightsource
@@ -2551,11 +2982,17 @@ sub zero ice cream,sub zero nitrogen ice cream
 substance fitness studio,substance fitness
 suburban extended stay hotel,suburban studios
 suburban extended stay hotel or suburban lodge,suburban studios
+suburban extended stay hotel suburban lodge,suburban studios
+suburban extended stay hotel suburban lodge suburban,suburban studios
 subway sandwhich shop,subway
 sugaring la,sugaringla
+suki hana chicken connection,suki hana
 suki hana restaurants,suki hana
+suki hana restaurants chicken connection,suki hana
+suki hana restaurants chicken connection restaurants,suki hana
 sukihana,suki hana
 sukihana chicken connection,suki hana
+sun management group,sun management
 sun spray spa,itan sun spray spa
 sunbelt,sunbelt business brokers
 sunbelt business advisors network,sunbelt business brokers
@@ -2564,9 +3001,13 @@ super 8,super 8 wyndham
 super 8 motels,super 8 wyndham
 super america,superamerica
 surestay hotel best western,surestay hotel
+surestay hotel group,surestay hotel
 sushi maru express,sushi maru
+svn commercial real estate advisors,svn
+svn franchised business,svn
 sweat,sweat440
 sweat circuit,sweat circuit gym
+sweathouz infrared saunas,sweathouz
 sweet arleens cupcakes bread puddings,sweet arleens
 sweet candy,NA
 sweet frog,sweetfrog
@@ -2582,9 +3023,11 @@ sweeto burritotm,sweeto burrito
 sweetwaters,sweets4treats
 sweetwaters café,sweetwaters coffee tea
 sweetwaters coffee 5 tea,sweetwaters coffee tea
+swensens ice cream,swensens
 swimlabs rehab,swimlabs
 sydnee pet grooming,sydnees pet grooming
 sylvan,sylvan learning
+sylvan learning center sylvansync,sylvan learning
 sylvan learning centers,sylvan learning
 synergy,synergy homecare
 system4 facility services,system4
@@ -2605,13 +3048,16 @@ take 5 oil change,take 5 oil change center
 take it to max fitness for mind body spint transformation center,max challenge
 take it to max fitness for mind body spirit,max challenge
 take it to max fitness for mind body spnit,max challenge
+take it to the max fitness for the body mind spirit the max challenge,max challenge
 take oil change,take 5 oil change center
 tap snap,tapsnap
 tapestry,tapster
+tapestry collection,tapestry collection hilton
 taquena chispa,taqueria chispa
 tastea tea bars,tastea
 taylor rental grand rental station,taylor rental
 taylor rental grand rental station party central,taylor rental
+taylor rental grand rental station party central commercial sales,taylor rental
 taylormane,taylormaries
 taylormarie’s apparel,taylormaries
 tazikis mediterranean café,tazikis mediterranean cafe
@@ -2627,14 +3073,15 @@ tenyaki madness,teriyaki madness
 teriyaki madness sept,teriyaki madness
 textile experts,crdn
 tga premier junior golf,tga
+tga premier junior tennis,tga
 tga premier sports,tga
 tga premier tennis,tga
 tga premier youth tennis,tga
 thanks pizza outlet,thanks pizza
 the alternative board,tab the alternative board
 the c12,c12 group
-the entrepreneur’s source,entrepreneurs source
 the entrepreneur's source (tes),entrepreneurs source
+the entrepreneur’s source,entrepreneurs source
 the homemag,home mag
 the interface financial group (ifg 50-50 program),interface financial group ifg 50 50
 the joint chiropractic place,joint chiropractic
@@ -2645,6 +3092,7 @@ the original mel's diner,original mels
 the rush studiocycle,rush cycle
 the soccer post store,soccer post
 thinique,thinique medical weight loss
+third eye pies independent taco,third eye pies
 thrifty,thrifty car rental
 thrifty car rent,thrifty car rental
 thrifty rent,thrifty car rental
@@ -2658,17 +3106,22 @@ tilden for brakes car care centers,tilden your total car care center
 tilden your total car care centers,tilden your total car care center
 tilted kilt,tilted kilt pub eatery
 tilted kilt operating,tilted kilt pub eatery
+tilted kilt restaurant,tilted kilt pub eatery
 tint world 04,tint world
+tint world automotive styling centers,tint world
 tippi toes dance,tippi toes
 tire pro's,tire pros
 tire pros center,tire pros
 tire prosody center,tire pros
 tirepro,tire pros
 title boxing,title boxing club
+tns retail store,tns
 toby latin grill,tobys latin grill
 tobys latin gnll,tobys latin grill
 tofu house,bcd tofu house
 togos eateries,togos
+togos restaurant,togos
+tokyo joes restaurant,tokyo joes
 tom n toms coffeehouse,tom n toms coffee
 tom plumber,1 tom plumber
 tom toms coffeehouse,tom n toms coffee
@@ -2680,8 +3133,10 @@ toniguy hairdressing academy,toni guy hairdressing
 tony lukes 11,tony lukes
 tony roma,tony romas
 tony romas a place for ribs,tony romas
+tony romas restaurant tr fire grill,tony romas
 tony romas tr fire grill,tony romas
 tony sacco’s coal oven kitchen,tony saccos coal oven kitchen
+top dog daycare,canine campus
 top rail,top rail fence
 top round,top round roast beef
 toppers,toppers pizza
@@ -2689,6 +3144,7 @@ toro tax,toro taxes
 tortiliaz healthy mexican grill,tortillaz healthy mexican grill
 tossed restaurant,tossed
 total nutrition superstores,NA
+towneplace,towneplace suites marriott
 towneplace suites,towneplace suites marriott
 tracy anderson method,tracy anderson
 trademark collection,trademark collection wyndham
@@ -2703,22 +3159,30 @@ travelleader,travel leaders
 travelodge,travelodge wyndham
 trend hotels and suites by my place (trend),trend hotels suites my place
 trend transformations granite transformations,trend transformations
+trimana fresh market trimana express salad got soup tacolimon got soup pizza benne pasta benne,salad got soup
+trimana trimana express trimana fresh market salad got soup tacolimon got soup pizza benne pasta benne,trimana
+trolley pub trolley party tiki pub paddle pub,trolley pub
 tropical juice bar,tropical smoothie cafe
-tropical smoothie café,tropical smoothie cafe
 tropical smoothie cafe sept,tropical smoothie cafe
+tropical smoothie café,tropical smoothie cafe
 tru bowl,tru bowl superfoods bar
+trublue house care,trublue
+trublue housecare,trublue
 trublue total house care,trublue
 true north,true north restoration
+true rest float spa,true rest
 true rest spa,true rest
 true value,true value rental
 true value rentals,true value rental
 true value specialty,true value rental
 trufusion wellness center,trufusion
+trunana trunana express salad got soup tacolimon,salad got soup
 trustegrity global,trustegrity
 tsaôcaa,tsaocaa
 tss photo,tss photography
 tssphoto,tss photography
 tsuta,tsuta japanese soba noodles
+tsuta uniform,tsuta japanese soba noodles
 ttpb,traveling photo booth
 tubbys sub shop,tubbys
 tuffy associates,tuffy tire auto service
@@ -2728,6 +3192,8 @@ tutor doctor sept,tutor doctor
 tutu school system dance movement programs for children,tutu school
 twin peaks restaurant,twin peaks
 two hands corn dogs,two hands
+two hands corn dogs outlet,two hands
+two hands corn dogs outlets,two hands
 two hands outlet,two hands
 two hands outlets,two hands
 two maids a mop,two maids
@@ -2735,18 +3201,21 @@ two men,two men a truck
 tws temporary wall systems,temporary wall
 u build it,ubuildit
 u s lawns,us lawns
+u swirl frozen yogurt also yogurtini cherryberry,u swirl frozen yogurt
 u swirl frozen yogurt yogurtini cherryberry,u swirl frozen yogurt
+u swirl frozen yogurt yogurtini cherryberry usi stores,u swirl frozen yogurt
 u-swirl frozen yogurt (also yogurtini),u swirl frozen yogurt
-ubatuba a√ßai bowls,ubatuba acai bowls
-ubatuba açai bowls,ubatuba acai bowls
-ubatuba açaí bowls,ubatuba acai bowls
 ubatuba acai bowls cafes,ubatuba acai bowls
 ubatuba aqai bowls,ubatuba acai bowls
+ubatuba açai bowls,ubatuba acai bowls
+ubatuba açaí bowls,ubatuba acai bowls
+ubatuba a√ßai bowls,ubatuba acai bowls
 ubreakifix,ubreakifix asurion
 ucmas mental math schools,ucmas mental math school
 ultimate fitness group,ultimate staffing services
 ululani’s hawaiian shave ice,ululanis hawaiian shave ice
 una mas restaurants,una mas
+unbound collection,unbound collection hyatt
 uncle maddio pizza joint,uncle maddios pizza
 uncle maddios pizza joint,uncle maddios pizza
 uncles pizza,uncle ds new york pizza
@@ -2766,11 +3235,14 @@ united hardware,hardware hank
 united national real estate,united real estate
 united real estate brokerage,united real estate
 united shipping solutions,united marketing solutions
+united snack group,united snack
 united soccer league,usl championship
 united soccer leagues,usl championship
 united water,united water restoration
+united water restoration group,united water restoration
 units group,units
 units moving portable storage,units
+units storage,units
 unity road,unity rd
 uno chicago grill uno due go,uno due go
 uno chicagopizzeria grill,pizzeria uno
@@ -2792,12 +3264,17 @@ vagabond inns,vagabond inn
 valenta bpo,valenta
 valentinos restaurant,valentinos
 valpak direct marketing,valpak
+value place,woodspring suites
 value place services,value place
 valvoline,valvoline instant oil change
 vanguard cleaning systems central valley,vanguard cleaning
 vanguard cleaning systems inland northwest,vanguard cleaning
 vanguard cleaning systems minnesota,vanguard cleaning
+vanguard cleaning systems se wisconsin,vanguard cleaning
 vanguard cleaning systems the inland northwest,vanguard cleaning
+vanguard cleaning systems the southern valley,vanguard cleaning
+vanguard cleaning systems upstate new york,vanguard cleaning
+vanguard cleaning systems washington,vanguard cleaning
 vanguard cleaning systems wisconsin,vanguard cleaning
 vapor group,vapor galleria
 velofix group companies,velofix
@@ -2808,9 +3285,16 @@ vicinis nyc pizza,vicinis new york pizzeria
 victory lane,victory lane quick oil change
 victory lane centers,victory lane quick oil change
 vida flo unit fa,vida flo hydration station
+vignette,vignette collection
 villa fresh italian kitchen,villa pizza
+villa fresh italian kitchen villa italian kitchen cozzolis,villa pizza
 villa fresh italian kitchen villa italian kitchen cozzolis tony bennys,tony bennys
+villa fresh italian kitchen villa italian kitchen tony bennys,villa pizza
+villa fresh italian kitchen villa italian kitchen villa pronto cozzolis,villa pizza
+villa pizza llc tony bennys,villa pizza
+villa pizza villa fresh italian kitchen villa italian kitchen tony bennys,tony bennys
 vitanya wellness center,vitanya
+voco hotels,voco
 volve,pvolve
 volvo rents,volvo construction equipment rents
 vom fass,vomfass
@@ -2821,6 +3305,8 @@ vons chicken restaurants,vons chicken
 voodoo brewery,voodoo brewing
 voodoobbq,voodoo bbq grill
 w here,w here real estate
+waba grill teriyaki house,waba grill
+waffys belgian waffles,waffys
 wag n wash natural food bakery,wag n wash
 wag n wash natural pet food grooming,wag n wash
 wag wash,wag n wash
@@ -2831,10 +3317,13 @@ walk ons,walk ons sports bistreaux
 walk ons bistreaux bar,walk ons sports bistreaux
 walk ons bistreaux bars,walk ons sports bistreaux
 walk ons restaurant,walk ons sports bistreaux
-walk-on’s sports bistreaux,walk ons sports bistreaux
 walk-on's sports bistreaux & bar,walk ons sports bistreaux
+walk-on’s sports bistreaux,walk ons sports bistreaux
+walkway management group,walkway management
 walsh associates,walsh associates church fundraising specia
 wanpo,wanpo tea shop
+wanpo usa master ca,wanpo tea shop
+wanpo usa unit area development,wanpo tea shop
 water life,alkaline h2o water life
 watermillexpress,watermill express
 waters edge winery,waters edge winery bistros
@@ -2845,19 +3334,23 @@ wavemax com laundry,wavemax laundry
 wavemax commission laundry,wavemax laundry
 wch center,wch service bureau
 we rock the spectrum kid's gyms,we rock the spectrum kids gym
+weichert real estate,weichert
 weichert realtors,weichert
 well health chiropractic center,well health chiropractic
 wendys old fashioned hamburgers,wendys
+wendys old fashioned hamburgers restaurants,wendys
 west,NA
+west coast sourdough west coast sourdough deli,west coast sourdough
 west coast tire auto center,west coast tires auto center
 westcoast brooks burgers,west coast brooks burgers
 westin,westin hotels resorts
 westin hotel,westin hotels resorts
 westin hotel management,westin hotels resorts
 westin hotels,westin hotels resorts
-wetzel’s pretzels,wetzels pretzels
 wetzelss pretzels,wetzels pretzels
+wetzel’s pretzels,wetzels pretzels
 wg storage,wg storage delivery
+wg storage moving,wg storage delivery
 whealthy restaurant,whealthy
 wheelmaxx off road auto repair,wheelmaxx
 which wich superior sandwiches,which wich
@@ -2873,11 +3366,13 @@ wildbirds,wild bird centers
 win business,win home inspection
 winchell's donuts,winchells
 winchells donut,winchells
+winchells donut shops,winchells
 winchelts donut,yum yum donuts
 windermere,windermere real estate
 windermere real estate services company,windermere real estate
 windermere services,windermere real estate
 window restoration replacement specialists,glass guru
+wingate,wingate wyndham
 wingate inn,wingate wyndham
 wingate inn by wyndham,wingate wyndham
 wingate inn wingate wyndham,wingate wyndham
@@ -2889,12 +3384,14 @@ wmchelts donut,yum yum donuts
 wood grill,ufood grill
 woodhouse,woodhouse day spa
 woodhouse spa,woodhouse day spa
+woodspring suites woodspring suites signature,woodspring suites
 woof gang bakery grooming,woof gang bakery
 woofie’s,woofies
 woofs,woofies
 work lodge,worklodge
 workout anytime 24 7,workout anytime
 world bean,NA
+world beer bar kitchen,world beer
 world home inspection network,win home inspection
 worldwide expr,worldwide express
 wow café wingery accoun,wow cafe wingery
@@ -2928,23 +3425,28 @@ yi mei deli,yi mei
 yifang fruit tea,yi fang taiwan fruit tea
 yimeideli,yi mei
 yogafit studio,yogafit
+yogafit studios,yogafit
 yogasix,yoga six
 yogen friiz,yogen fruz
 yogi bear jellystone park camp resort,yogi bears jellystone park camp resort
-yogi bear’s jellystone park camp-resort,yogi bears jellystone park camp resort
 yogi bears jellystone park camp resorts,yogi bears jellystone park camp resort
+yogi bear’s jellystone park camp-resort,yogi bears jellystone park camp resort
 yoo collection hotel or a yoo2 hotel,yoo hotels
 you move me 414 v,you move me
-you’ve got maids,youve got maids
 young dabang outlet,young dabang
 young dabang outlets,young dabang
 young rembrandt(s),young rembrandts
+you’ve got maids,youve got maids
 yukdaejang restaurants,yukdaejang
 yum yum donut,yum yum donuts
+yummi sushi yummi sauces toshimi calmon sushi sara,yummi sushi
 z pizza,zpizza
 zaaz,zaaz studios
 zaaz branding,zaaz studios
+zaaz practitioner outlets,zaaz studios
+zaaz practitioner outlets kiosks,zaaz studios
 zaaz studio,zaaz studios
+zagg retail,zagg
 zava zone,zavazone
 zavazone indoor adventure park,zavazone
 zaxby,zaxbys
@@ -2958,6 +3460,8 @@ zippy shell moving storage,zippy shell
 zippy shell self storage moving,zippy shell
 zips cleaners,zips dry cleaners
 zo skin health,zo skin centre
+zo skin health centre,zo skin centre
+zoo express health club zoo health club,zoo health club
 zoo health club zoo express health club,zoo health club
 zooga yoga,zooga
 zoom sewer drain cleaning,zoom drain
@@ -2970,96 +3474,4 @@ zpizza restaurant,zpizza
 zzaam fresh,zzaam fresh korean grill
 zzaam fresh korean gnll,zzaam fresh korean grill
 яnr tire express,rnr tire express
-advantage performance group,advantage performance
-apg american prosperity group,apg american prosperity
-blue coast financial group,blue coast financial
-city sports marketing group,city sports marketing
-cleanest restaurant group,cleanest restaurant
-commercial investors group,commercial investors
-commonwealth care group,commonwealth care
-corporate cleaning group,corporate cleaning
-franchise development group,development group
-doan group,the doan
-estate group,estate
-go airport shuttle the go group go,go airport shuttle
-handyman group,handyman
-holtorf medical group,holtorf medical
-i4 search group,i4 search
-johnston tate wealth advisory group,johnston tate wealth advisory
-keystone insurers group,keystone insurers
-leadership development group,leadership
-luxury limo group,luxury limo
-maxim group,maxim
-professionals realty group,professionals realty
-realty one group,realty one
-reliable facility group,reliable facility
-signal health group,signal health
-sun management group,sun management
-surestay hotel group,surestay hotel
-united snack group,united snack
-united water restoration group,united water restoration
-walkway management group,walkway management
-irr residential,accurity valuation
-irr-residential,accurity valuation
-top dog daycare,canine campus
-jjs candy em,schwieterts cones candy
-jj s candy em,schwieterts cones candy
-sitters etc,sei healthcare services
-lodies shaved ice shack,summer snow
-lodie s shaved ice shack,summer snow
-johnny bruscos new york style pizza,johnnys new york style pizza
-johnny brusco s new york style pizza,johnnys new york style pizza
-kfc corporation,kfc
-rainbow station,leafspring school
-huntington school services,huntington learning center
-sparkle wash international cleaning service,sparkle wash
-canopy by hilton,canopy hilton
-conrad hotels,conrad hotels resorts
-homewood suites,homewood suites hilton
-home2 suites,home2 suites hilton
-livsmart,livsmart studios hilton
-livsmart studios,livsmart studios hilton
-lxr hotels,lxr hotels resorts
-tapestry collection,tapestry collection hilton
-atwell,atwell suites
-candlewood,candlewood suites
-holiday inn express,holiday inn
-kimpton hotels,kimpton hotels restaurants
-kimpton,kimpton hotels restaurants
-staybridge,staybridge suites
-vignette,vignette collection
-voco hotels,voco
-ac hotels,ac hotels marriott
-meridien,le meridien
-ritz carlton,ritz carlton residences
-ritzcarlton,ritz carlton residences
-towneplace,towneplace suites marriott
-springhill,springhill suites marriott
-apartments marriott,apartments marriott bonvoy
-jdv,jdv hyatt
-unbound collection,unbound collection hyatt
-howard johnson,howard johnson wyndham
-ramada,ramada wyndham
-la quinta,la quinta wyndham
-wingate,wingate wyndham
-dolce hotels,dolce
-dolce wyndham,dolce
-dolce hotels resorts,dolce
-dolce hotels resorts wyndham,dolce
-echo suites,echo suites extended stay wyndham
-echo wyndham,echo suites extended stay wyndham
-everhome,everhome suites extended stay choice hotels
-value place,woodspring suites
-mainstay,mainstay suites extended stay choice hotels
-redroof inn,red roof inn
-redroof,red roof inn
-hometowne,hometowne studios red roof
-hometowne studios,hometowne studios red roof
-midas speedee,midas speedee oil change auto service
-athletic revolution,fitness revolution
-marilyn monroe glamour,marilyn monroe spas
-s t o p,drymedic restoration services
-salon plaza,my salon suite
-egg i am,egg i
-r k cafe,rice king
-rk cafe,rice king
+—ènr tire express,rnr tire express

--- a/data/harmonize-names.csv
+++ b/data/harmonize-names.csv
@@ -3451,6 +3451,7 @@ zava zone,zavazone
 zavazone indoor adventure park,zavazone
 zaxby,zaxbys
 zaxby\'s,zaxbys
+zeeks,zeeks pizza
 zero degrees restaurant,zero degrees
 ziebart rustproofing,ziebart
 zifit infrared fitness,red effect infrared fitness


### PR DESCRIPTION
## Summary
- Adds 413 harmonization rules for franchise names that appear in FDDs with trailing descriptors, regional qualifiers, multi-brand listings, or other long-form variants of names already in the master file
- Most are long-form to short canonical mappings (e.g., "togos restaurant" to "togos", "jan pro northwest" to "jan pro cleaning disinfecting")
- A smaller share are spelling variants and alias corrections (e.g., "conroys flowers" to "1 800 flowers")
- Generated from unmatched names in the franchise-metadata pipeline, filtered to only include high-confidence matches
- File was resorted alphabetically